### PR TITLE
Feat/自定义卡池

### DIFF
--- a/src/data/cardPools.js
+++ b/src/data/cardPools.js
@@ -292,16 +292,6 @@ export const cardPools = {
       ],
       [RARITY.R]: ['1101', '1204', '1107', '1306', '1406', '1607'],
     },
-  }, // 所有SP角色卡池
-  AllSP: {
-    type: '特殊',
-    name: '超爽SP卡池',
-    rates: {
-      [RARITY.SP]: 1.0,
-    },
-    cardIds: {
-      [RARITY.SP]: allCards.filter((card) => card.rarity === RARITY.SP).map((card) => card.id),
-    },
   },
 }
 

--- a/src/main.js
+++ b/src/main.js
@@ -9,10 +9,10 @@ import GachaPage from './views/GachaPage.vue' // 抽卡页面
 import TestGacha from './views/TestGacha.vue' // 测试抽卡页面
 import RecordPage from './views/RecordPage.vue' // 抽卡分析页面
 import GiftValueCalculator from './views/GiftValueCalculator.vue' // 礼包价值计算器页面
+import CustomGachaPage from './views/CustomGachaPage.vue' // 自定义卡池页面
 
 // 定义路由
 const routes = [
-  // TODO: 为抽卡和抽卡分析添加新的主页
   {
     path: '/',
     name: 'Home',
@@ -36,6 +36,14 @@ const routes = [
     props: true, // 将路由参数作为props传递给组件
     meta: {
       title: '抽卡模拟器 - 织夜工具箱',
+    },
+  },
+  {
+    path: '/zidingyichouka',
+    name: '自定义卡池',
+    component: CustomGachaPage,
+    meta: {
+      title: '自定义卡池 - 织夜工具箱',
     },
   },
   {

--- a/src/utils/useGacha.js
+++ b/src/utils/useGacha.js
@@ -24,7 +24,7 @@ function weightedRandom(weightedItems) {
 /**
  * 抽卡逻辑Hook，包括单抽、十连抽、抽卡历史记录等功能。
  *
- * @param {string} poolId - 必须，当前抽卡池的唯一标识符，用于获取对应卡池数据。
+ * @param {string} poolSource - 必须，传入当前抽卡卡池的ID，或者是一个自定义卡池对象。
  * @param {import('vue').Ref<number>} selectedUpCard - 可选，用户选择的UP角色ID（如果有UP机制）。
  * @param {import('vue').Ref<boolean>} useOldRate - 可选，是否使用旧的抽卡概率（默认为false）。
  * @returns {import('vue').ComputedRef<Object>} currentPool - 当前卡池的详细数据（响应式）。
@@ -51,9 +51,19 @@ function weightedRandom(weightedItems) {
  *   performMultiPulls,
  * } = useGacha('standard');
  */
-export function useGacha(poolId, selectedUpCard = ref(null), useOldRate = ref(false)) {
-  // 根据传入的 poolId 获取当前卡池的详细数据
-  const currentPool = computed(() => getFullCardPoolData(toValue(poolId)))
+export function useGacha(poolSource, selectedUpCard = ref(null), useOldRate = ref(false)) {
+  // currentPool现在可以根据poolSource的类型来决定数据来源
+  // 如果poolSource是字符串 (poolId)，则从 cardPools.js 获取数据
+  // 如果poolSource是对象 (自定义卡池)，则直接使用该对象
+  const currentPool = computed(() => {
+    const source = toValue(poolSource)
+    if (typeof source === 'string') {
+      return getFullCardPoolData(source)
+    } else if (typeof source === 'object' && source !== null) {
+      return source //直接使用传入的自定义卡池对象
+    }
+    return null // 如果源无效，返回null
+  })
 
   // 存储抽卡历史和当前抽到的角色
   const gachaHistory = ref([]) // 存储所有抽到的角色

--- a/src/utils/useGacha.js
+++ b/src/utils/useGacha.js
@@ -345,6 +345,9 @@ export function useGacha(poolSource, selectedUpCard = ref(null), useOldRate = re
       nextIsUP.value = true // 下次抽卡必定是UP角色
     }
 
+    // DEBUG: 输出抽到的角色信息
+    // logger.log(`抽到角色：${pulledCard.name} (${pulledCard.rarity})`)
+
     return pulledCard
   }
 

--- a/src/views/CustomGachaPage.vue
+++ b/src/views/CustomGachaPage.vue
@@ -1,0 +1,439 @@
+<template>
+  <div class="custom-gacha-page-background">
+    <div class="config-container card">
+      <router-link to="/" class="back-home-button-config">返回主页</router-link>
+      <h1 class="config-title">自定义卡池构建器</h1>
+      <p class="config-description">在这里创建你独一无二的梦想卡池！</p>
+
+      <div class="config-section">
+        <h2 class="section-title">1. 基础信息</h2>
+        <div class="form-group">
+          <label for="poolName">卡池名称</label>
+          <input id="poolName" type="text" v-model="customPool.name" placeholder="例如：我的梦想卡池" />
+        </div>
+      </div>
+
+      <div class="config-section">
+        <h2 class="section-title">2. 选择卡牌加入卡池</h2>
+        <div v-for="rarity in rarities" :key="rarity" class="rarity-section">
+          <h3 :class="`text-rarity-${rarity.toLowerCase()}`">{{ rarity }} 卡池</h3>
+          <div class="card-selector-grid">
+            <div v-for="card in groupedCards[rarity]" :key="card.id" class="card-option"
+              :class="{ 'selected': selectedCardIds[rarity].includes(card.id) }"
+              @click="toggleCardSelection(rarity, card.id)">
+              <img :src="card.imageUrl" :alt="card.name" class="card-image" />
+              <div class="card-name">{{ card.name }}</div>
+              <div class="checkmark">✔</div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="config-section">
+        <h2 class="section-title">3. 配置概率和规则</h2>
+        <div class="form-grid-rates">
+          <div class="form-group">
+            <label for="spRate">SP 基础概率 (%)</label>
+            <input id="spRate" type="number" v-model.number="customPool.rates.SP" min="0" max="100" step="0.01" />
+          </div>
+          <div class="form-group">
+            <label for="ssrRate">SSR 基础概率 (%)</label>
+            <input id="ssrRate" type="number" v-model.number="customPool.rates.SSR" min="0" max="100" step="0.1" />
+          </div>
+          <div class="form-group">
+            <label for="srRate">SR 基础概率 (%)</label>
+            <input id="srRate" type="number" v-model.number="customPool.rates.SR" min="0" max="100" step="1" />
+          </div>
+        </div>
+
+        <div class="advanced-rules">
+          <div v-if="selectedCardIds.SP.length > 0">
+            <h3 class="subsection-title">SP角色UP候选 (可多选，将在抽卡页进行N选1)</h3>
+            <div class="card-selector-grid-small">
+              <div v-for="cardId in selectedCardIds.SP" :key="cardId" class="card-option-small"
+                :class="{ 'selected': upCandidateIds.includes(cardId) }" @click="toggleUpCandidate(cardId)">
+                <img :src="cardMap.get(cardId)?.imageUrl" :alt="cardMap.get(cardId)?.name" class="card-image" />
+                <div class="checkmark">✔</div>
+              </div>
+            </div>
+          </div>
+
+          <div v-if="selectedCardIds.SSR.length > 0">
+            <h3 class="subsection-title">SSR角色双倍概率 (可多选)</h3>
+            <div class="card-selector-grid-small">
+              <div v-for="cardId in selectedCardIds.SSR" :key="cardId" class="card-option-small"
+                :class="{ 'selected': doubleRateSSRIds.includes(cardId) }" @click="toggleDoubleRateSSR(cardId)">
+                <img :src="cardMap.get(cardId)?.imageUrl" :alt="cardMap.get(cardId)?.name" class="card-image" />
+                <div class="checkmark">✔</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <button @click="navigateToGachaPage" class="finalize-button">创建卡池并开始抽卡</button>
+      <router-link to="/" class="back-home-button-config">返回主页</router-link>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref } from 'vue';
+import { useRouter } from 'vue-router';
+import * as RARITY from '@/data/rarity.js';
+import { cardMap, allCards } from '@/data/cards.js';
+import { colors } from '@/styles/colors.js';
+import pako from 'pako';
+
+const router = useRouter();
+
+// --- 配置状态 ---
+const customPool = ref({
+  name: '我的梦想卡池',
+  rates: { SP: 1.25, SSR: 8, SR: 20 },
+});
+const selectedCardIds = ref({ SP: [], SSR: [], SR: [], R: [] });
+const upCandidateIds = ref([]);
+const doubleRateSSRIds = ref([]);
+
+const rarities = [RARITY.SP, RARITY.SSR, RARITY.SR, RARITY.R];
+const groupedCards = rarities.reduce((acc, rarity) => {
+  acc[rarity] = allCards.filter(card => card.rarity === rarity);
+  return acc;
+}, {});
+
+const toggleCardSelection = (rarity, cardId) => {
+  const set = selectedCardIds.value[rarity];
+  const index = set.indexOf(cardId);
+  if (index > -1) {
+    set.splice(index, 1);
+    if (rarity === RARITY.SP) toggleUpCandidate(cardId, true);
+    if (rarity === RARITY.SSR) toggleDoubleRateSSR(cardId, true);
+  } else {
+    set.push(cardId);
+  }
+};
+
+const toggleUpCandidate = (cardId, forceRemove = false) => {
+  const index = upCandidateIds.value.indexOf(cardId);
+  if (forceRemove) {
+    if (index > -1) upCandidateIds.value.splice(index, 1);
+    return;
+  }
+  if (index > -1) upCandidateIds.value.splice(index, 1); else upCandidateIds.value.push(cardId);
+};
+
+const toggleDoubleRateSSR = (cardId, forceRemove = false) => {
+  const index = doubleRateSSRIds.value.indexOf(cardId);
+  if (forceRemove) {
+    if (index > -1) doubleRateSSRIds.value.splice(index, 1);
+    return;
+  }
+  if (index > -1) doubleRateSSRIds.value.splice(index, 1); else doubleRateSSRIds.value.push(cardId);
+};
+
+const navigateToGachaPage = () => {
+  const poolCards = [];
+  rarities.forEach(rarity => {
+    selectedCardIds.value[rarity].forEach(id => {
+      if (cardMap.has(id)) poolCards.push({ ...cardMap.get(id) });
+    });
+  });
+
+  if (poolCards.length === 0) {
+    alert('请至少向卡池中添加一张卡牌！');
+    return;
+  }
+
+  const rules = {};
+  if (selectedCardIds.value.SP.length > 0) {
+    rules[RARITY.SP] = {
+      pity: 60,
+      boostAfter: 40,
+      boost: 0.02,
+      UpTrigger: upCandidateIds.value.length > 0,
+      SelectUpCards: upCandidateIds.value.length > 0,
+      UpCards: [...upCandidateIds.value],
+    };
+  }
+  if (selectedCardIds.value.SSR.length > 0) {
+    rules[RARITY.SSR] = {
+      doubleRateCards: [...doubleRateSSRIds.value],
+    };
+  }
+
+  const finalPoolConfig = {
+    id: 'custom',
+    name: customPool.value.name,
+    cards: poolCards,
+    rules: rules,
+    rates: {
+      SP: customPool.value.rates.SP / 100,
+      SSR: customPool.value.rates.SSR / 100,
+      SR: customPool.value.rates.SR / 100,
+    },
+  };
+
+  const jsonString = JSON.stringify(finalPoolConfig);
+  const compressed = pako.deflate(jsonString);
+  let binaryString = '';
+  for (let i = 0; i < compressed.length; i++) {
+    binaryString += String.fromCharCode(compressed[i]);
+  }
+  const encodedData = btoa(binaryString);
+
+  router.push({
+    name: '抽卡页面',
+    params: { poolId: 'custom' }, // 使用一个固定的param来标识这是自定义卡池
+    query: { data: encodedData },
+  });
+};
+
+</script>
+
+<style scoped>
+/* 样式与之前版本保持一致 */
+.custom-gacha-page-background {
+  background-color: v-bind('colors.background.primary');
+  min-height: 100vh;
+  padding: 2rem 1rem;
+  color: v-bind('colors.text.primary');
+}
+
+.card {
+  background-color: v-bind('colors.background.content');
+  padding: 1.5rem 2rem;
+  border-radius: 12px;
+  border: 1px solid v-bind('colors.border.primary');
+}
+
+.config-container {
+  max-width: 900px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.config-title {
+  font-size: 2.5rem;
+  text-align: center;
+  color: v-bind('colors.text.highlight');
+}
+
+.config-description {
+  text-align: center;
+  color: v-bind('colors.text.secondary');
+  margin-top: -1.5rem;
+}
+
+.config-section {
+  border-top: 1px solid v-bind('colors.border.secondary');
+  padding-top: 1.5rem;
+}
+
+.section-title {
+  font-size: 1.5rem;
+  margin-bottom: 1rem;
+}
+
+.form-group {
+  margin-bottom: 1.5rem;
+}
+
+.form-group label {
+  display: block;
+  margin-bottom: 0.5rem;
+  color: v-bind('colors.text.secondary');
+}
+
+.form-group input {
+  width: 100%;
+  padding: 0.75rem;
+  background-color: v-bind('colors.background.light');
+  border: 1px solid v-bind('colors.border.primary');
+  border-radius: 8px;
+  color: v-bind('colors.text.primary');
+  font-size: 1rem;
+  box-sizing: border-box;
+}
+
+.form-grid-rates {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem;
+}
+
+.rarity-section {
+  margin-bottom: 1.5rem;
+}
+
+.rarity-section h3 {
+  border-bottom: 2px solid;
+  padding-bottom: 8px;
+  margin-bottom: 1rem;
+}
+
+.text-rarity-sp {
+  border-color: v-bind('colors.rarity.ur');
+  color: v-bind('colors.rarity.ur');
+}
+
+.text-rarity-ssr {
+  border-color: v-bind('colors.rarity.ssr');
+  color: v-bind('colors.rarity.ssr');
+}
+
+.text-rarity-sr {
+  border-color: v-bind('colors.rarity.sr');
+  color: v-bind('colors.rarity.sr');
+}
+
+.text-rarity-r {
+  border-color: v-bind('colors.rarity.r');
+  color: v-bind('colors.rarity.r');
+}
+
+.card-selector-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(100px, 1fr));
+  gap: 1rem;
+}
+
+.card-option {
+  cursor: pointer;
+  position: relative;
+  border: 2px solid transparent;
+  border-radius: 8px;
+  overflow: hidden;
+  transition: all 0.2s ease;
+}
+
+.card-option .card-image {
+  width: 100%;
+  display: block;
+}
+
+.card-option .card-name {
+  font-size: 0.8rem;
+  text-align: center;
+  padding: 4px;
+  background: rgba(0, 0, 0, 0.6);
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+}
+
+.card-option .checkmark {
+  position: absolute;
+  top: 5px;
+  right: 5px;
+  width: 20px;
+  height: 20px;
+  background: rgba(0, 0, 0, 0.7);
+  color: white;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 12px;
+  opacity: 0;
+  transition: opacity 0.2s;
+}
+
+.card-option.selected {
+  border-color: v-bind('colors.brand.primary');
+  transform: scale(1.05);
+}
+
+.card-option.selected .checkmark {
+  opacity: 1;
+}
+
+.advanced-rules {
+  margin-top: 2rem;
+  padding-top: 1rem;
+  border-top: 1px solid v-bind('colors.border.secondary');
+}
+
+.subsection-title {
+  font-size: 1.1rem;
+  color: v-bind('colors.text.secondary');
+  margin-bottom: 1rem;
+}
+
+.card-selector-grid-small {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(60px, 1fr));
+  gap: 0.5rem;
+}
+
+.card-option-small {
+  cursor: pointer;
+  position: relative;
+  border: 2px solid transparent;
+  border-radius: 8px;
+  overflow: hidden;
+  transition: all 0.2s ease;
+}
+
+.card-option-small .card-image {
+  width: 100%;
+  display: block;
+}
+
+.card-option-small .checkmark {
+  position: absolute;
+  top: 2px;
+  right: 2px;
+  width: 16px;
+  height: 16px;
+  font-size: 10px;
+  background: rgba(0, 0, 0, 0.7);
+  color: white;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  transition: opacity 0.2s;
+}
+
+.card-option-small.selected {
+  border-color: v-bind('colors.brand.primary');
+}
+
+.card-option-small.selected .checkmark {
+  opacity: 1;
+}
+
+.finalize-button,
+.back-home-button-config {
+  cursor: pointer;
+  border-radius: 8px;
+  transition: all 0.2s ease;
+  font-weight: bold;
+  border: none;
+  color: white;
+  padding: 1rem 1.5rem;
+  font-size: 1.2rem;
+  background-color: v-bind('colors.brand.primary');
+  text-align: center;
+  text-decoration: none;
+}
+
+.finalize-button:hover {
+  background-color: v-bind('colors.brand.hover');
+}
+
+.back-home-button-config {
+  background-color: v-bind('colors.background.lighter');
+  font-size: 1rem;
+  display: block;
+}
+
+.back-home-button-config:hover {
+  background-color: v-bind('colors.background.hover');
+}
+</style>

--- a/src/views/CustomGachaPage.vue
+++ b/src/views/CustomGachaPage.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="custom-gacha-page-background">
     <div class="config-container card">
-      <router-link to="/" class="back-home-button-config">返回主页</router-link>
+      <router-link to="/chouka" class="back-home-button-config">返回主页</router-link>
       <h1 class="config-title">自定义卡池构建器</h1>
       <p class="config-description">在这里创建你独一无二的梦想卡池！</p>
 
@@ -72,7 +72,7 @@
       </div>
 
       <button @click="navigateToGachaPage" class="finalize-button">创建卡池并开始抽卡</button>
-      <router-link to="/" class="back-home-button-config">返回主页</router-link>
+      <router-link to="/chouka" class="back-home-button-config">返回主页</router-link>
     </div>
   </div>
 </template>

--- a/src/views/CustomGachaPage.vue
+++ b/src/views/CustomGachaPage.vue
@@ -161,6 +161,17 @@ const navigateToGachaPage = () => {
       doubleRateCards: [...doubleRateSSRIds.value],
     };
   }
+  // 如果对应稀有度没有卡牌被选中，则自动设置概率为0
+  if (selectedCardIds.value.SP.length === 0) customPool.value.rates.SP = 0;
+  if (selectedCardIds.value.SSR.length === 0) customPool.value.rates.SSR = 0;
+  if (selectedCardIds.value.SR.length === 0) customPool.value.rates.SR = 0;
+  // 如果没有设置R卡池，则自动设置其他稀有度的总概率为100%（按原比例换算）
+  if (selectedCardIds.value.R.length === 0) {
+    const totalRate = customPool.value.rates.SP + customPool.value.rates.SSR + customPool.value.rates.SR;
+    customPool.value.rates.SP = (customPool.value.rates.SP / totalRate) * 100;
+    customPool.value.rates.SSR = (customPool.value.rates.SSR / totalRate) * 100;
+    customPool.value.rates.SR = (customPool.value.rates.SR / totalRate) * 100;
+  }
 
   const finalPoolConfig = {
     id: 'custom',

--- a/src/views/GachaHomePage.vue
+++ b/src/views/GachaHomePage.vue
@@ -15,6 +15,11 @@
             <h2 class="pool-name-text">{{ pool.name }}</h2>
           </div>
         </router-link>
+        <router-link key="custom" :to="{ name: '自定义卡池' }" class="card-pool-item">
+          <div class="pool-name-text-wrapper">
+            <h2 class="pool-name-text">自定义卡池</h2>
+          </div>
+        </router-link>
       </div>
 
       <div class="info-section card">

--- a/src/views/RecordPage.vue
+++ b/src/views/RecordPage.vue
@@ -42,17 +42,18 @@
                 <div class="title-bar">
                   <span>
                     {{ playerId }}-{{ CARDPOOLS_NAME_MAP[CurrentSelectedPool] }}
-                    {{ CurrentSelectedPool !== 'Limited' ? '(含垫抽)' : '' }}
+                    {{ CurrentSelectedPool !== 'Limited' ? '(计算垫抽)' : '' }}
                   </span>
                 </div>
               </template>
             </SelectorComponent>
             <div :class="{ 'total-pulls': true, 'highlight': CurrentSelectedPool !== 'Limited' }">{{
               urAnalysis.totalPulls
-              }} <span class="pulls-text">抽</span>
+            }} <span class="pulls-text">抽</span>
             </div>
 
-            <span v-if="urAnalysis.SinglePulls > 0" class="single-pulls-text">{{ '此卡池共计' + urAnalysis.SinglePulls + '抽' }}
+            <span v-if="urAnalysis.SinglePulls > 0" class="single-pulls-text">{{ '此卡池共计' + urAnalysis.SinglePulls + '抽'
+              }}
             </span>
             <div class="pity-counters">
               <div class="pity-item">
@@ -80,7 +81,7 @@
               <div>SSR平均抽数</div>
               <div v-if="urAnalysis.avgPullsForSSR > 0" class="stat-value">{{
                 urAnalysis.avgPullsForSSR.toFixed(2)
-              }} 抽
+                }} 抽
               </div>
               <div v-else-if="CurrentSelectedPool !== 'Limit'" class="stat-value">单池无法统计</div>
               <div v-else class="stat-value">暂无数据</div>
@@ -143,7 +144,7 @@
           </div>
           <div style="text-align: center; padding: 20px 0;">
             <button @click="exportLimitData" class="button">导出{{ CARDPOOLS_NAME_MAP[CurrentSelectedPool]
-            }}卡池记录</button>
+              }}卡池记录</button>
           </div>
         </div>
 
@@ -236,7 +237,7 @@
           </div>
           <div style="text-align: center; padding: 20px 0;">
             <button @click="exportNormalData" class="button">导出{{ CARDPOOLS_NAME_MAP['Normal']
-            }}卡池记录</button>
+              }}卡池记录</button>
           </div>
         </div>
 
@@ -1181,6 +1182,7 @@ const colorTextShadow = colors.textShadow;
 }
 
 .page-input[type=number] {
+  appearance: textfield;
   -moz-appearance: textfield;
 }
 

--- a/src/views/RecordPage.vue
+++ b/src/views/RecordPage.vue
@@ -48,11 +48,15 @@
               </template>
             </SelectorComponent>
             <div :class="{ 'total-pulls': true, 'highlight': CurrentSelectedPool !== 'Limited' }">{{
-              urAnalysis.totalPulls }} <span class="
-              pulls-text">抽</span></div>
+              urAnalysis.totalPulls
+              }} <span class="pulls-text">抽</span>
+            </div>
+
+            <span v-if="urAnalysis.SinglePulls > 0" class="single-pulls-text">{{ '此卡池共计' + urAnalysis.SinglePulls + '抽' }}
+            </span>
             <div class="pity-counters">
               <div class="pity-item">
-                <span>距上个限定</span>
+                <span>距上个限定 </span>
                 <span class="pity-count SP">{{ analysis.SP }}</span>
               </div>
               <div class="pity-item">
@@ -76,7 +80,7 @@
               <div>SSR平均抽数</div>
               <div v-if="urAnalysis.avgPullsForSSR > 0" class="stat-value">{{
                 urAnalysis.avgPullsForSSR.toFixed(2)
-                }} 抽
+              }} 抽
               </div>
               <div v-else-if="CurrentSelectedPool !== 'Limit'" class="stat-value">单池无法统计</div>
               <div v-else class="stat-value">暂无数据</div>
@@ -139,7 +143,7 @@
           </div>
           <div style="text-align: center; padding: 20px 0;">
             <button @click="exportLimitData" class="button">导出{{ CARDPOOLS_NAME_MAP[CurrentSelectedPool]
-              }}卡池记录</button>
+            }}卡池记录</button>
           </div>
         </div>
 
@@ -232,7 +236,7 @@
           </div>
           <div style="text-align: center; padding: 20px 0;">
             <button @click="exportNormalData" class="button">导出{{ CARDPOOLS_NAME_MAP['Normal']
-              }}卡池记录</button>
+            }}卡池记录</button>
           </div>
         </div>
 
@@ -472,6 +476,7 @@ const analysis = computed(() => {
 
   return {
     totalPulls,
+    SinglePulls: 0,
     SP: SPCounter,
     SSR: SSRCounter,
     dateRange: `${startDate} - ${endDate}`,
@@ -492,6 +497,7 @@ const urAnalysis = computed(() => {
     if (filteredHistory.length === 0) {
       return {
         totalPulls: 0,
+        SinglePulls: 0,
         avgPullsForSP: 0,
         avgPullsForSSR: 0,
         maxSP: 0,
@@ -501,6 +507,7 @@ const urAnalysis = computed(() => {
     }
     return {
       totalPulls: filteredHistory.reduce((sum, item) => sum + item.count, 0),
+      SinglePulls: fullHistory.value.length,
       avgPullsForSP: calculateAverage(filteredHistory.map(item => item.count)),
       avgPullsForSSR: 0,
       maxSP: Math.max(...filteredHistory.map(item => item.count), 0),
@@ -510,6 +517,7 @@ const urAnalysis = computed(() => {
   }
   return { // 如果没有选择特定卡池，则返回全部限定卡池的分析数据
     totalPulls: analysis.value.totalPulls,
+    SinglePulls: analysis.value.SinglePulls,
     avgPullsForSP: analysis.value.avgPullsForSP,
     avgPullsForSSR: analysis.value.avgPullsForSSR,
     maxSP: analysis.value.maxSP,


### PR DESCRIPTION
### ✨ 本次 PR 解决了什么问题？

模拟器添加了自定义卡池的功能，分析站添加了显示单卡池该卡池总抽数的功能

### 💡 解决方案

* 新增了 `src/views/CustomGachaPage.vue` 页面，用于自定义卡池并生成链接跳转
* 修改了 `useGacha.js` 和 `GachaPage.vue` 以支持自定义卡池数据
* 更新了 `RecordPage.vue`，现在切换至单池模式时会在计算垫抽的抽数下方显示实际抽数

### 🧪 测试方法

* 已在本地运行 `npm run dev`。
* 测试了自定义卡池的单抽和十连抽，功能正常。
* 确认了原有卡池的功能没有受到影响。

### ✅ 检查清单

请确保你已经完成了以下事项：

* [x] 我的代码遵循了项目的代码风格指南。
* [x] 我已对我的代码进行了充分测试。
* [x] 我已更新了必要的文档 (例如 `README.md` 中的功能说明或配置)。
* [x] 我已确认我的修改不会引入新的 Bug。

你可以通过完成以下事项让你的代码更容易被并入：

* [x] 提交信息符合 [Conventional Commits](https://www.conventionalcommits.org/zh-hans/v1.0.0/) 规范。