### PR TITLE
feat: 徽章攻略 D1 数据系统与玩家投稿功能

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,9 @@
+{
+  "permissions": {
+    "allow": [
+      "mcp__4b7ec826-9775-462c-a1b2-d461ee482cf6__accounts_list",
+      "mcp__4b7ec826-9775-462c-a1b2-d461ee482cf6__set_active_account",
+      "mcp__4b7ec826-9775-462c-a1b2-d461ee482cf6__d1_database_create"
+    ]
+  }
+}

--- a/_worker.js
+++ b/_worker.js
@@ -145,6 +145,501 @@ export class TaskRunner {
   // }
 }
 
+// ============================================================
+//  徽章攻略系统 — 管理员 Token 工具函数
+// ============================================================
+
+/**
+ * 签发管理员 Token（HMAC-SHA256，24小时有效期）
+ * 环境变量：ADMIN_SECRET（签名密钥）
+ */
+async function signAdminToken(env) {
+  const now = Date.now()
+  const payload = JSON.stringify({ iat: now, exp: now + 24 * 60 * 60 * 1000 })
+  const payloadB64 = btoa(payload).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '')
+  const key = await crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(env.ADMIN_SECRET),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  )
+  const sig = await crypto.subtle.sign('HMAC', key, new TextEncoder().encode(payloadB64))
+  const sigB64 = btoa(String.fromCharCode(...new Uint8Array(sig)))
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=/g, '')
+  return `${payloadB64}.${sigB64}`
+}
+
+/**
+ * 验证管理员 Token，返回 true/false
+ */
+async function verifyAdminToken(token, env) {
+  if (!token || !env.ADMIN_SECRET) return false
+  try {
+    const dotIdx = token.lastIndexOf('.')
+    if (dotIdx === -1) return false
+    const payloadB64 = token.slice(0, dotIdx)
+    const sigB64 = token.slice(dotIdx + 1)
+    const key = await crypto.subtle.importKey(
+      'raw',
+      new TextEncoder().encode(env.ADMIN_SECRET),
+      { name: 'HMAC', hash: 'SHA-256' },
+      false,
+      ['verify'],
+    )
+    const sigBytes = Uint8Array.from(
+      atob(sigB64.replace(/-/g, '+').replace(/_/g, '/')),
+      (c) => c.charCodeAt(0),
+    )
+    const valid = await crypto.subtle.verify(
+      'HMAC',
+      key,
+      sigBytes,
+      new TextEncoder().encode(payloadB64),
+    )
+    if (!valid) return false
+    const paddedPayload =
+      payloadB64.replace(/-/g, '+').replace(/_/g, '/') +
+      '='.repeat((4 - (payloadB64.length % 4)) % 4)
+    const payload = JSON.parse(atob(paddedPayload))
+    return Date.now() < payload.exp
+  } catch {
+    return false
+  }
+}
+
+/**
+ * 计算密码哈希：SHA-256(ADMIN_SALT + password) → hex
+ */
+async function hashPassword(password, salt) {
+  const data = new TextEncoder().encode((salt || '') + password)
+  const hashBuf = await crypto.subtle.digest('SHA-256', data)
+  return Array.from(new Uint8Array(hashBuf))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('')
+}
+
+// ============================================================
+//  徽章攻略 Hono 子路由
+// ============================================================
+const hzApp = new Hono()
+
+// ── 公开接口 ──────────────────────────────────────────────
+
+/**
+ * GET /api/hz/version
+ * 返回当前攻略数据版本号（1次D1读取）
+ */
+hzApp.get('/version', async (c) => {
+  try {
+    const row = await c.env.HZ_DB.prepare(
+      'SELECT version, updated_at FROM hz_guide_meta WHERE id = 1',
+    ).first()
+    return c.json({ version: row?.version ?? '0', updated_at: row?.updated_at ?? 0 })
+  } catch (e) {
+    return c.json({ message: '数据库查询失败: ' + e.message }, 500)
+  }
+})
+
+/**
+ * GET /api/hz/guides
+ * 返回所有已审核攻略（1次D1 batch读取）
+ */
+hzApp.get('/guides', async (c) => {
+  try {
+    const [metaRes, guidesRes] = await c.env.HZ_DB.batch([
+      c.env.HZ_DB.prepare('SELECT version, updated_at FROM hz_guide_meta WHERE id = 1'),
+      c.env.HZ_DB.prepare(
+        'SELECT id, char_id, code, title, author_name, user_id, is_featured, created_at, approved_at FROM hz_guides ORDER BY approved_at DESC',
+      ),
+    ])
+    const meta = metaRes.results[0] ?? { version: '0', updated_at: 0 }
+    return c.json({
+      version: meta.version,
+      updated_at: meta.updated_at,
+      guides: guidesRes.results,
+    })
+  } catch (e) {
+    return c.json({ message: '数据库查询失败: ' + e.message }, 500)
+  }
+})
+
+/**
+ * POST /api/hz/submit
+ * 投稿攻略（验证激活码 + 限速 + 写入待审核）
+ */
+hzApp.post('/submit', async (c) => {
+  const licenseKey = c.req.header('X-License-Key')
+  if (!licenseKey) {
+    return c.json({ message: '请提供激活码（X-License-Key 请求头）' }, 401)
+  }
+
+  let userId
+  try {
+    const result = await verifyLicenseForWorker(licenseKey, c.env.PUBLIC_KEY)
+    userId = String(result.userId)
+  } catch (e) {
+    return c.json({ message: '激活码无效: ' + e.message }, 403)
+  }
+
+  let body
+  try {
+    body = await c.req.json()
+  } catch {
+    return c.json({ message: '请求体格式错误，请发送 JSON' }, 400)
+  }
+
+  const { charId, code, title = '', authorName = '' } = body
+
+  // 参数校验
+  if (!charId || !/^\d+$/.test(String(charId))) {
+    return c.json({ message: 'charId 格式错误' }, 400)
+  }
+  if (!code || typeof code !== 'string' || code.length > 15360) {
+    return c.json({ message: '攻略代码无效或超出大小限制（15KB）' }, 400)
+  }
+  if (typeof title !== 'string' || title.length > 100) {
+    return c.json({ message: '标题过长（最多100字符）' }, 400)
+  }
+  if (typeof authorName !== 'string' || authorName.length > 100) {
+    return c.json({ message: '署名过长（最多100字符）' }, 400)
+  }
+
+  try {
+    // 限速检查：同一 userId 3分钟内只能投稿1次
+    const lastRow = await c.env.HZ_DB.prepare(
+      'SELECT submitted_at FROM hz_pending WHERE user_id = ? ORDER BY submitted_at DESC LIMIT 1',
+    )
+      .bind(userId)
+      .first()
+
+    if (lastRow) {
+      const elapsed = Date.now() - lastRow.submitted_at
+      const RATE_LIMIT_MS = 3 * 60 * 1000
+      if (elapsed < RATE_LIMIT_MS) {
+        const timeLeft = RATE_LIMIT_MS - elapsed
+        return c.json(
+          {
+            message: `提交过于频繁，请 ${Math.ceil(timeLeft / 1000)} 秒后再试`,
+            timeLeft,
+          },
+          429,
+        )
+      }
+    }
+
+    const now = Date.now()
+    await c.env.HZ_DB.prepare(
+      'INSERT INTO hz_pending (char_id, code, title, author_name, user_id, submitted_at) VALUES (?, ?, ?, ?, ?, ?)',
+    )
+      .bind(String(charId), code, title.trim(), authorName.trim(), userId, now)
+      .run()
+
+    return c.json({ message: '提交成功！攻略将在审核通过后显示。' }, 201)
+  } catch (e) {
+    return c.json({ message: '数据库操作失败: ' + e.message }, 500)
+  }
+})
+
+// ── 管理员认证接口 ────────────────────────────────────────
+
+/**
+ * POST /api/hz/admin/auth
+ * 密码验证，成功签发管理员 Token
+ * IP 限速：5次失败 → 封禁60分钟（存于现有 KV）
+ */
+hzApp.post('/admin/auth', async (c) => {
+  if (!c.env.ADMIN_PASSWORD_HASH || !c.env.ADMIN_SECRET) {
+    return c.json({ message: '管理员功能未配置' }, 503)
+  }
+
+  const ip = c.req.header('CF-Connecting-IP') || 'unknown'
+  const bruteKey = `hz_admin_brute_${ip}`
+
+  // 读取暴力破解记录
+  let brute = { count: 0, blockedUntil: 0 }
+  try {
+    const raw = await c.env.GACHA_PARTY_RECORDS.get(bruteKey)
+    if (raw) brute = JSON.parse(raw)
+  } catch { /* 忽略 */ }
+
+  if (brute.blockedUntil > Date.now()) {
+    const remaining = Math.ceil((brute.blockedUntil - Date.now()) / 60000)
+    return c.json(
+      { message: `登录尝试次数过多，请 ${remaining} 分钟后再试` },
+      429,
+    )
+  }
+
+  let body
+  try {
+    body = await c.req.json()
+  } catch {
+    return c.json({ message: '请求体格式错误' }, 400)
+  }
+
+  const { password } = body
+  if (!password || typeof password !== 'string') {
+    return c.json({ message: '请输入密码' }, 400)
+  }
+
+  const hash = await hashPassword(password, c.env.ADMIN_SALT || '')
+  if (hash !== c.env.ADMIN_PASSWORD_HASH) {
+    brute.count = (brute.count || 0) + 1
+    if (brute.count >= 5) {
+      brute.blockedUntil = Date.now() + 60 * 60 * 1000
+    }
+    await c.env.GACHA_PARTY_RECORDS.put(bruteKey, JSON.stringify(brute), {
+      expirationTtl: 7200,
+    })
+    const attemptsLeft = Math.max(0, 5 - brute.count)
+    return c.json(
+      {
+        message: attemptsLeft > 0 ? `密码错误，剩余尝试次数：${attemptsLeft}` : '密码错误，账号已被暂时锁定',
+        attemptsLeft,
+      },
+      401,
+    )
+  }
+
+  // 验证成功：清除暴力破解记录
+  await c.env.GACHA_PARTY_RECORDS.delete(bruteKey)
+  const token = await signAdminToken(c.env)
+  return c.json({ token })
+})
+
+// ── 管理员操作接口（统一 Token 验证中间件）────────────────
+
+const adminRouter = new Hono()
+
+// Token 验证中间件
+adminRouter.use('*', async (c, next) => {
+  const authHeader = c.req.header('Authorization') || ''
+  const token = authHeader.startsWith('Bearer ') ? authHeader.slice(7) : null
+  const valid = await verifyAdminToken(token, c.env)
+  if (!valid) return c.json({ message: '未授权，请重新登录' }, 401)
+  await next()
+})
+
+/**
+ * GET /api/hz/admin/pending?page=N
+ * 分页获取待审核攻略
+ */
+adminRouter.get('/pending', async (c) => {
+  const page = Math.max(1, parseInt(c.req.query('page') || '1'))
+  const perPage = 20
+  const offset = (page - 1) * perPage
+  try {
+    const [countRes, rowsRes] = await c.env.HZ_DB.batch([
+      c.env.HZ_DB.prepare('SELECT COUNT(*) as total FROM hz_pending'),
+      c.env.HZ_DB.prepare(
+        'SELECT * FROM hz_pending ORDER BY submitted_at DESC LIMIT ? OFFSET ?',
+      ).bind(perPage, offset),
+    ])
+    return c.json({
+      total: countRes.results[0]?.total ?? 0,
+      page,
+      perPage,
+      items: rowsRes.results,
+    })
+  } catch (e) {
+    return c.json({ message: '查询失败: ' + e.message }, 500)
+  }
+})
+
+/**
+ * POST /api/hz/admin/approve/:id
+ * 审核通过：pending → guides，更新版本
+ */
+adminRouter.post('/approve/:id', async (c) => {
+  const id = parseInt(c.req.param('id'))
+  if (isNaN(id)) return c.json({ message: 'id 格式错误' }, 400)
+
+  try {
+    const pending = await c.env.HZ_DB.prepare('SELECT * FROM hz_pending WHERE id = ?')
+      .bind(id)
+      .first()
+    if (!pending) return c.json({ message: '待审核条目不存在' }, 404)
+
+    const now = Date.now()
+    const newVersion = String(now)
+
+    await c.env.HZ_DB.batch([
+      c.env.HZ_DB.prepare(
+        'INSERT INTO hz_guides (char_id, code, title, author_name, user_id, is_featured, created_at, approved_at) VALUES (?, ?, ?, ?, ?, 0, ?, ?)',
+      ).bind(
+        pending.char_id,
+        pending.code,
+        pending.title,
+        pending.author_name,
+        pending.user_id,
+        pending.submitted_at,
+        now,
+      ),
+      c.env.HZ_DB.prepare('DELETE FROM hz_pending WHERE id = ?').bind(id),
+      c.env.HZ_DB.prepare(
+        'UPDATE hz_guide_meta SET version = ?, updated_at = ? WHERE id = 1',
+      ).bind(newVersion, now),
+    ])
+
+    return c.json({ message: '审核通过', newVersion })
+  } catch (e) {
+    return c.json({ message: '操作失败: ' + e.message }, 500)
+  }
+})
+
+/**
+ * DELETE /api/hz/admin/pending/:id
+ * 拒绝并删除待审核攻略
+ */
+adminRouter.delete('/pending/:id', async (c) => {
+  const id = parseInt(c.req.param('id'))
+  if (isNaN(id)) return c.json({ message: 'id 格式错误' }, 400)
+  try {
+    const result = await c.env.HZ_DB.prepare('DELETE FROM hz_pending WHERE id = ?')
+      .bind(id)
+      .run()
+    if (result.changes === 0) return c.json({ message: '条目不存在' }, 404)
+    return c.json({ message: '已拒绝并删除' })
+  } catch (e) {
+    return c.json({ message: '操作失败: ' + e.message }, 500)
+  }
+})
+
+/**
+ * GET /api/hz/admin/guides?page=N
+ * 分页获取已审核攻略列表
+ */
+adminRouter.get('/guides', async (c) => {
+  const page = Math.max(1, parseInt(c.req.query('page') || '1'))
+  const perPage = 20
+  const offset = (page - 1) * perPage
+  try {
+    const [countRes, rowsRes] = await c.env.HZ_DB.batch([
+      c.env.HZ_DB.prepare('SELECT COUNT(*) as total FROM hz_guides'),
+      c.env.HZ_DB.prepare(
+        'SELECT id, char_id, title, author_name, user_id, is_featured, approved_at FROM hz_guides ORDER BY approved_at DESC LIMIT ? OFFSET ?',
+      ).bind(perPage, offset),
+    ])
+    return c.json({
+      total: countRes.results[0]?.total ?? 0,
+      page,
+      perPage,
+      items: rowsRes.results,
+    })
+  } catch (e) {
+    return c.json({ message: '查询失败: ' + e.message }, 500)
+  }
+})
+
+/**
+ * DELETE /api/hz/admin/guide/:id
+ * 删除已审核攻略，更新版本
+ */
+adminRouter.delete('/guide/:id', async (c) => {
+  const id = parseInt(c.req.param('id'))
+  if (isNaN(id)) return c.json({ message: 'id 格式错误' }, 400)
+  try {
+    const now = Date.now()
+    await c.env.HZ_DB.batch([
+      c.env.HZ_DB.prepare('DELETE FROM hz_guides WHERE id = ?').bind(id),
+      c.env.HZ_DB.prepare(
+        'UPDATE hz_guide_meta SET version = ?, updated_at = ? WHERE id = 1',
+      ).bind(String(now), now),
+    ])
+    return c.json({ message: '已删除' })
+  } catch (e) {
+    return c.json({ message: '操作失败: ' + e.message }, 500)
+  }
+})
+
+/**
+ * PATCH /api/hz/admin/guide/:id/feature
+ * 切换精选状态，更新版本
+ */
+adminRouter.patch('/guide/:id/feature', async (c) => {
+  const id = parseInt(c.req.param('id'))
+  if (isNaN(id)) return c.json({ message: 'id 格式错误' }, 400)
+  let body
+  try {
+    body = await c.req.json()
+  } catch {
+    return c.json({ message: '请求体格式错误' }, 400)
+  }
+  const featured = body.featured ? 1 : 0
+  try {
+    const now = Date.now()
+    await c.env.HZ_DB.batch([
+      c.env.HZ_DB.prepare('UPDATE hz_guides SET is_featured = ? WHERE id = ?').bind(
+        featured,
+        id,
+      ),
+      c.env.HZ_DB.prepare(
+        'UPDATE hz_guide_meta SET version = ?, updated_at = ? WHERE id = 1',
+      ).bind(String(now), now),
+    ])
+    return c.json({ message: featured ? '已设为精选' : '已取消精选' })
+  } catch (e) {
+    return c.json({ message: '操作失败: ' + e.message }, 500)
+  }
+})
+
+/**
+ * POST /api/hz/admin/seed
+ * 一次性迁移静态数据（接受 { entries: [{ charId, codes[] }] }）
+ */
+adminRouter.post('/seed', async (c) => {
+  let body
+  try {
+    body = await c.req.json()
+  } catch {
+    return c.json({ message: '请求体格式错误' }, 400)
+  }
+  const { entries } = body
+  if (!Array.isArray(entries)) {
+    return c.json({ message: 'entries 必须是数组' }, 400)
+  }
+
+  const now = Date.now()
+  const statements = []
+
+  for (const entry of entries) {
+    if (!entry.charId || !/^\d+$/.test(String(entry.charId))) continue
+    if (!Array.isArray(entry.codes)) continue
+    for (const code of entry.codes) {
+      if (typeof code !== 'string' || code.length > 15360) continue
+      statements.push(
+        c.env.HZ_DB.prepare(
+          'INSERT INTO hz_guides (char_id, code, title, author_name, user_id, is_featured, created_at, approved_at) VALUES (?, ?, ?, ?, ?, 0, ?, ?)',
+        ).bind(entry.charId, code, '', '官方导入', '0', now, now),
+      )
+    }
+  }
+
+  const insertCount = statements.length
+  statements.push(
+    c.env.HZ_DB.prepare(
+      'UPDATE hz_guide_meta SET version = ?, updated_at = ? WHERE id = 1',
+    ).bind(String(now), now),
+  )
+
+  try {
+    // D1 batch 每次最多100条，分块处理
+    const CHUNK_SIZE = 99
+    for (let i = 0; i < statements.length; i += CHUNK_SIZE) {
+      await c.env.HZ_DB.batch(statements.slice(i, i + CHUNK_SIZE))
+    }
+    return c.json({ message: `迁移完成，共导入 ${insertCount} 条攻略` })
+  } catch (e) {
+    return c.json({ message: '迁移失败: ' + e.message }, 500)
+  }
+})
+
+// 挂载管理员子路由
+hzApp.route('/admin', adminRouter)
+
 const mainApp = new Hono()
 
 // 增强的 CORS 配置，支持动态 localhost 端口
@@ -380,6 +875,9 @@ function base64UrlToStandard(base64url) {
 //   }
 //   return { data: newlyFetched, error: null }
 // }
+
+// 挂载徽章攻略子路由
+mainApp.route('/api/hz', hzApp)
 
 mainApp.get('/get-record', async (c) => {
   try {
@@ -629,6 +1127,7 @@ export default {
     // 检查是否是 API 请求。如果是，则由 Hono 应用处理。
     // 这里列出您所有的 API 路径前缀。
     const isApiRequest =
+      url.pathname.startsWith('/api/hz/') ||
       url.pathname.startsWith('/start-update-task') ||
       url.pathname.startsWith('/task-status/') ||
       url.pathname.startsWith('/get-record') ||

--- a/hz_schema.sql
+++ b/hz_schema.sql
@@ -1,0 +1,36 @@
+-- 徽章攻略系统 D1 数据库初始化脚本
+-- 运行命令：wrangler d1 execute gacha-party-hz --file=hz_schema.sql --remote
+
+-- 全局版本控制（单行表，id 固定为 1）
+CREATE TABLE IF NOT EXISTS hz_guide_meta (
+  id INTEGER PRIMARY KEY CHECK(id = 1),
+  version TEXT NOT NULL DEFAULT '0',
+  updated_at INTEGER NOT NULL DEFAULT 0
+);
+
+-- 已审核通过的攻略
+CREATE TABLE IF NOT EXISTS hz_guides (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  char_id TEXT NOT NULL,
+  code TEXT NOT NULL,
+  title TEXT NOT NULL DEFAULT '',
+  author_name TEXT NOT NULL DEFAULT '',
+  user_id TEXT NOT NULL DEFAULT '',
+  is_featured INTEGER NOT NULL DEFAULT 0,
+  created_at INTEGER NOT NULL,
+  approved_at INTEGER NOT NULL
+);
+
+-- 待审核的投稿
+CREATE TABLE IF NOT EXISTS hz_pending (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  char_id TEXT NOT NULL,
+  code TEXT NOT NULL,
+  title TEXT NOT NULL DEFAULT '',
+  author_name TEXT NOT NULL DEFAULT '',
+  user_id TEXT NOT NULL,
+  submitted_at INTEGER NOT NULL
+);
+
+-- 初始化版本行
+INSERT OR IGNORE INTO hz_guide_meta (id, version, updated_at) VALUES (1, '0', 0);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gacha-party",
-  "version": "4.2.2",
+  "version": "4.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gacha-party",
-      "version": "4.2.2",
+      "version": "4.2.3",
       "dependencies": {
         "@eslint/compat": "^2.0.0",
         "@icon-park/vue-next": "^1.4.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gacha-party",
-  "version": "4.2.2",
+  "version": "4.2.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/components/HuizhangSubmitModal.vue
+++ b/src/components/HuizhangSubmitModal.vue
@@ -1,0 +1,392 @@
+<template>
+  <div class="overlay" @click.self="emit('close')">
+    <div class="submit-modal">
+      <h3 class="modal-title">投稿攻略</h3>
+      <p class="modal-sub">投稿后需要管理员审核，审核通过后将显示在攻略列表中。</p>
+
+      <!-- 激活码输入 -->
+      <div class="form-row">
+        <label class="form-label">激活码 <span class="required">*</span></label>
+        <div class="input-with-eye">
+          <input
+            :type="showKey ? 'text' : 'password'"
+            v-model="licenseKey"
+            class="form-input"
+            placeholder="粘贴你的激活码"
+            autocomplete="off"
+          />
+          <button class="eye-btn" @click="showKey = !showKey" type="button">
+            {{ showKey ? '隐藏' : '显示' }}
+          </button>
+        </div>
+        <label class="checkbox-row">
+          <input type="checkbox" v-model="saveKey" />
+          <span>保存激活码到本地（下次自动填充）</span>
+        </label>
+      </div>
+
+      <!-- 攻略代码 -->
+      <div class="form-row">
+        <label class="form-label">攻略代码 <span class="required">*</span></label>
+        <textarea
+          v-model="code"
+          class="code-textarea"
+          rows="4"
+          placeholder="在编辑器中创建攻略后，点击「导出代码」获取代码，粘贴到此处..."
+        ></textarea>
+        <a :href="`/huizhang/edit?charId=${charId}`" target="_blank" class="hint-link">
+          前往编辑器创建攻略 →
+        </a>
+      </div>
+
+      <!-- 标题和署名 -->
+      <div class="compact-row">
+        <div class="form-row compact-col">
+          <label class="form-label">攻略标题（可选）</label>
+          <input
+            v-model="title"
+            class="form-input"
+            maxlength="100"
+            placeholder="如：高伤输出配置"
+          />
+        </div>
+        <div class="form-row compact-col">
+          <label class="form-label">署名（可选）</label>
+          <input
+            v-model="authorName"
+            class="form-input"
+            maxlength="100"
+            placeholder="你的昵称"
+          />
+        </div>
+      </div>
+
+      <!-- 状态反馈 -->
+      <div v-if="errorMsg" class="feedback-msg error-msg">{{ errorMsg }}</div>
+      <div v-if="successMsg" class="feedback-msg success-msg">{{ successMsg }}</div>
+
+      <!-- 操作按钮 -->
+      <div class="form-actions">
+        <button
+          class="form-btn primary"
+          :disabled="submitting"
+          @click="handleSubmit"
+        >
+          {{ submitting ? '提交中…' : '提交审核' }}
+        </button>
+        <button class="form-btn cancel" @click="emit('close')">取消</button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue'
+import { colors } from '@/styles/colors.js'
+import { decodeStrategy } from '@/utils/huizhangCode.js'
+import { useHuizhangGuides } from '@/composables/useHuizhangGuides.js'
+
+const props = defineProps({
+  charId: { type: String, required: true },
+})
+const emit = defineEmits(['close', 'submitted'])
+
+const { getWorkerBase } = useHuizhangGuides()
+
+const licenseKey = ref('')
+const saveKey = ref(false)
+const showKey = ref(false)
+const code = ref('')
+const title = ref('')
+const authorName = ref('')
+const submitting = ref(false)
+const errorMsg = ref('')
+const successMsg = ref('')
+
+onMounted(() => {
+  const saved = localStorage.getItem('hz_license_key')
+  if (saved) {
+    licenseKey.value = saved
+    saveKey.value = true
+  }
+})
+
+const handleSubmit = async () => {
+  errorMsg.value = ''
+  successMsg.value = ''
+
+  // 本地校验
+  if (!licenseKey.value.trim()) {
+    errorMsg.value = '请输入激活码'
+    return
+  }
+  if (!code.value.trim()) {
+    errorMsg.value = '请粘贴攻略代码'
+    return
+  }
+
+  // 本地预校验代码是否可解析
+  try {
+    decodeStrategy(code.value.trim())
+  } catch {
+    errorMsg.value = '攻略代码格式无效，请确认代码完整且未损坏'
+    return
+  }
+
+  // 保存激活码
+  if (saveKey.value) {
+    localStorage.setItem('hz_license_key', licenseKey.value.trim())
+  }
+
+  submitting.value = true
+  try {
+    const base = getWorkerBase()
+    const res = await fetch(`${base}/api/hz/submit`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-License-Key': licenseKey.value.trim(),
+      },
+      body: JSON.stringify({
+        charId: props.charId,
+        code: code.value.trim(),
+        title: title.value.trim(),
+        authorName: authorName.value.trim(),
+      }),
+    })
+
+    const data = await res.json()
+
+    if (!res.ok) {
+      if (res.status === 429 && data.timeLeft) {
+        const secs = Math.ceil(data.timeLeft / 1000)
+        errorMsg.value = `提交过于频繁，请 ${secs} 秒后再试`
+      } else {
+        errorMsg.value = data.message || '提交失败，请稍后重试'
+      }
+    } else {
+      successMsg.value = data.message || '提交成功！攻略将在审核通过后显示。'
+      setTimeout(() => emit('submitted'), 1500)
+    }
+  } catch {
+    errorMsg.value = '网络错误，请检查网络连接后重试'
+  } finally {
+    submitting.value = false
+  }
+}
+</script>
+
+<style scoped>
+.overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background-color: v-bind('colors.background.overlay');
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+}
+
+.submit-modal {
+  background-color: v-bind('colors.background.content');
+  padding: 1.4rem 1.6rem;
+  border-radius: 14px;
+  box-shadow: 0 8px 24px v-bind('colors.shadow.primary');
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  width: 90%;
+  max-width: 480px;
+  border: 1px solid v-bind('colors.border.primary');
+  max-height: 90vh;
+  overflow-y: auto;
+}
+
+.modal-title {
+  text-align: center;
+  margin: 0;
+  color: v-bind('colors.text.primary');
+  font-size: 1.1rem;
+}
+
+.modal-sub {
+  text-align: center;
+  margin: -0.5rem 0 0;
+  color: v-bind('colors.text.tertiary');
+  font-size: 0.8rem;
+  line-height: 1.4;
+}
+
+.form-row {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.form-label {
+  font-weight: bold;
+  font-size: 0.85rem;
+  color: v-bind('colors.text.secondary');
+}
+
+.required {
+  color: v-bind('colors.brand.cancel');
+}
+
+.input-with-eye {
+  display: flex;
+  gap: 6px;
+}
+
+.form-input {
+  width: 100%;
+  padding: 8px 10px;
+  border-radius: 7px;
+  border: 1px solid v-bind('colors.input.border');
+  background: v-bind('colors.input.background');
+  color: v-bind('colors.input.text');
+  box-sizing: border-box;
+  font-size: 0.9rem;
+  flex: 1;
+}
+
+.form-input:focus {
+  outline: none;
+  border-color: v-bind('colors.brand.primary');
+}
+
+.eye-btn {
+  flex-shrink: 0;
+  padding: 8px 12px;
+  border-radius: 7px;
+  border: 1px solid v-bind('colors.border.primary');
+  background: v-bind('colors.background.lighter');
+  color: v-bind('colors.text.secondary');
+  cursor: pointer;
+  font-size: 0.82rem;
+  white-space: nowrap;
+}
+
+.eye-btn:hover {
+  border-color: v-bind('colors.brand.primary');
+  color: v-bind('colors.brand.primary');
+}
+
+.checkbox-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.82rem;
+  color: v-bind('colors.text.secondary');
+  cursor: pointer;
+  font-weight: normal;
+}
+
+.checkbox-row input[type='checkbox'] {
+  accent-color: v-bind('colors.brand.primary');
+  cursor: pointer;
+}
+
+.code-textarea {
+  width: 100%;
+  padding: 8px 10px;
+  border-radius: 7px;
+  border: 1px solid v-bind('colors.input.border');
+  background: v-bind('colors.input.background');
+  color: v-bind('colors.input.text');
+  box-sizing: border-box;
+  font-size: 0.82rem;
+  font-family: monospace;
+  resize: vertical;
+  min-height: 90px;
+}
+
+.code-textarea:focus {
+  outline: none;
+  border-color: v-bind('colors.brand.primary');
+}
+
+.hint-link {
+  color: v-bind('colors.brand.primary');
+  font-size: 0.78rem;
+  text-decoration: none;
+  align-self: flex-end;
+}
+
+.hint-link:hover {
+  text-decoration: underline;
+}
+
+.compact-row {
+  display: flex;
+  gap: 10px;
+}
+
+.compact-col {
+  flex: 1;
+  min-width: 0;
+}
+
+.feedback-msg {
+  font-size: 0.85rem;
+  padding: 8px 12px;
+  border-radius: 6px;
+  text-align: center;
+}
+
+.error-msg {
+  background: v-bind('colors.status.errorBg');
+  color: v-bind('colors.status.error');
+}
+
+.success-msg {
+  background: v-bind('colors.status.successBg');
+  color: v-bind('colors.status.success');
+}
+
+.form-actions {
+  display: flex;
+  gap: 10px;
+  margin-top: 4px;
+}
+
+.form-btn {
+  flex: 1;
+  padding: 0.55rem 1rem;
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 0.9rem;
+  font-weight: bold;
+  transition: all 0.15s;
+  border: 1px solid v-bind('colors.border.primary');
+  background: v-bind('colors.background.lighter');
+  color: v-bind('colors.text.primary');
+}
+
+.form-btn.primary {
+  background: v-bind('colors.brand.primary');
+  color: v-bind('colors.text.black');
+  border-color: v-bind('colors.brand.primary');
+}
+
+.form-btn.primary:hover:not(:disabled) {
+  background: v-bind('colors.brand.hover');
+}
+
+.form-btn.primary:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.form-btn.cancel {
+  color: v-bind('colors.text.secondary');
+}
+
+.form-btn.cancel:hover {
+  border-color: v-bind('colors.brand.primary');
+  color: v-bind('colors.brand.primary');
+}
+</style>

--- a/src/composables/useHuizhangGuides.js
+++ b/src/composables/useHuizhangGuides.js
@@ -1,0 +1,233 @@
+import { ref, readonly } from 'vue'
+import { decodeStrategy } from '@/utils/huizhangCode.js'
+
+// localStorage 缓存键
+const LS_KEY_DATA = 'hz_guide_data'
+const LS_KEY_VERSION = 'hz_guide_version'
+const LS_KEY_LAST_CHECK = 'hz_guide_last_check'
+
+// 4小时缓存有效期
+const CACHE_TTL_MS = 4 * 60 * 60 * 1000
+
+// 模块级单例状态，多组件共享
+const _guides = ref([])
+const _version = ref('0')
+const _loading = ref(false)
+const _error = ref(null)
+let _initPromise = null
+
+/**
+ * 获取 Worker 基础 URL（开发环境用 8787 端口，生产环境同源）
+ */
+function getWorkerBase() {
+  const url = new URL(window.location.href)
+  const isDev = url.hostname === 'localhost' || url.hostname === '127.0.0.1'
+  return isDev ? `${url.protocol}//${url.hostname}:8787` : url.origin
+}
+
+/**
+ * 安全解码攻略代码，失败返回 null
+ */
+function safeDecodeStrategy(code) {
+  try {
+    return decodeStrategy(code)
+  } catch {
+    return null
+  }
+}
+
+/**
+ * 将原始 D1 guide 对象格式化为前端使用的统一格式
+ */
+function formatGuide(g) {
+  return {
+    id: g.id,
+    charId: g.char_id,
+    code: g.code,
+    title: g.title || '',
+    authorName: g.author_name || '',
+    userId: g.user_id,
+    isFeatured: Boolean(g.is_featured),
+    createdAt: g.created_at,
+    approvedAt: g.approved_at,
+    data: safeDecodeStrategy(g.code),
+  }
+}
+
+/**
+ * 从 localStorage 加载缓存数据
+ * @returns {boolean} 是否成功加载
+ */
+function loadFromCache() {
+  try {
+    const raw = localStorage.getItem(LS_KEY_DATA)
+    const ver = localStorage.getItem(LS_KEY_VERSION)
+    if (raw && ver) {
+      _guides.value = JSON.parse(raw)
+      _version.value = ver
+      return true
+    }
+  } catch {
+    // 忽略 JSON 解析错误
+  }
+  return false
+}
+
+/**
+ * 将攻略数据保存到 localStorage
+ */
+function saveToCache(guides, version) {
+  try {
+    localStorage.setItem(LS_KEY_DATA, JSON.stringify(guides))
+    localStorage.setItem(LS_KEY_VERSION, version)
+    localStorage.setItem(LS_KEY_LAST_CHECK, String(Date.now()))
+  } catch {
+    // 忽略存储配额错误
+  }
+}
+
+/**
+ * 仅获取当前版本号（轻量请求）
+ */
+async function fetchVersion() {
+  const base = getWorkerBase()
+  const res = await fetch(`${base}/api/hz/version`)
+  if (!res.ok) throw new Error(`version 请求失败: ${res.status}`)
+  return res.json()
+}
+
+/**
+ * 获取全量攻略数据
+ */
+async function fetchAllGuides() {
+  const base = getWorkerBase()
+  const res = await fetch(`${base}/api/hz/guides`)
+  if (!res.ok) throw new Error(`guides 请求失败: ${res.status}`)
+  return res.json()
+}
+
+/**
+ * 内部初始化逻辑
+ */
+async function _doInit(forceFullRefresh) {
+  _loading.value = true
+  _error.value = null
+
+  try {
+    const lastCheck = parseInt(localStorage.getItem(LS_KEY_LAST_CHECK) || '0')
+    const now = Date.now()
+    const hasCachedData = loadFromCache()
+
+    if (forceFullRefresh || !hasCachedData) {
+      // 无缓存或强制刷新：全量拉取
+      const result = await fetchAllGuides()
+      _guides.value = result.guides || []
+      _version.value = result.version || '0'
+      saveToCache(_guides.value, _version.value)
+      return
+    }
+
+    if (now - lastCheck < CACHE_TTL_MS) {
+      // 缓存未过期，直接使用（数据已在 loadFromCache 中加载）
+      return
+    }
+
+    // 缓存过期：先更新检查时间戳，再轻量检查版本
+    localStorage.setItem(LS_KEY_LAST_CHECK, String(now))
+
+    let versionData
+    try {
+      versionData = await fetchVersion()
+    } catch (e) {
+      // 网络失败：保留现有缓存，不报错
+      console.warn('[useHuizhangGuides] 版本检查失败，使用本地缓存:', e.message)
+      return
+    }
+
+    if (versionData.version === _version.value) {
+      // 版本相同，缓存仍然有效
+      return
+    }
+
+    // 版本不同：全量刷新
+    try {
+      const result = await fetchAllGuides()
+      _guides.value = result.guides || []
+      _version.value = result.version || '0'
+      saveToCache(_guides.value, _version.value)
+    } catch (e) {
+      console.warn('[useHuizhangGuides] 全量拉取失败，使用旧缓存:', e.message)
+    }
+  } catch (e) {
+    _error.value = e.message
+    // 降级：保留已加载的缓存数据
+  } finally {
+    _loading.value = false
+  }
+}
+
+/**
+ * 初始化（幂等，多次调用共享同一 Promise）
+ */
+async function init(forceFullRefresh = false) {
+  if (_initPromise && !forceFullRefresh) return _initPromise
+  _initPromise = _doInit(forceFullRefresh)
+  return _initPromise
+}
+
+/**
+ * 强制绕过缓存重新拉取
+ */
+async function forceRefresh() {
+  _initPromise = null
+  return init(true)
+}
+
+/**
+ * 攻略数据 Composable
+ */
+export function useHuizhangGuides() {
+  return {
+    /** 原始攻略数组（只读） */
+    guides: readonly(_guides),
+    /** 当前版本号（只读） */
+    version: readonly(_version),
+    /** 加载状态（只读） */
+    loading: readonly(_loading),
+    /** 错误信息（只读） */
+    error: readonly(_error),
+
+    /**
+     * 初始化攻略数据（在 onMounted 中调用）
+     * @param {boolean} [forceFullRefresh=false] 是否强制全量刷新
+     */
+    init,
+
+    /**
+     * 强制重新拉取所有数据（绕过缓存）
+     */
+    forceRefresh,
+
+    /**
+     * 获取指定角色的所有攻略（已解码）
+     * @param {string} charId
+     * @returns {{ id, charId, code, title, authorName, userId, isFeatured, createdAt, approvedAt, data }[]}
+     */
+    getGuidesForChar(charId) {
+      return _guides.value.filter((g) => g.char_id === String(charId)).map(formatGuide)
+    },
+
+    /**
+     * 获取所有精选攻略（is_featured = 1）
+     * @returns {{ id, charId, code, title, authorName, userId, isFeatured, createdAt, approvedAt, data }[]}
+     */
+    getFeaturedGuides() {
+      return _guides.value.filter((g) => g.is_featured).map(formatGuide)
+    },
+
+    /**
+     * 获取 Worker 基础 URL（供其他地方直接 fetch 用）
+     */
+    getWorkerBase,
+  }
+}

--- a/src/main.js
+++ b/src/main.js
@@ -107,6 +107,14 @@ const routes = [
     },
   },
   {
+    path: '/huizhang/admin',
+    name: '徽章攻略管理',
+    component: () => import('./views/HuizhangAdmin.vue'),
+    meta: {
+      title: '徽章攻略管理 - 织夜工具箱',
+    },
+  },
+  {
     path: '/zako',
     name: 'Zako',
     component: () => import('./views/ZakoPage.vue'),

--- a/src/views/HuizhangAdmin.vue
+++ b/src/views/HuizhangAdmin.vue
@@ -1,0 +1,1075 @@
+<template>
+  <div class="page-container">
+    <!-- 登录界面 -->
+    <div v-if="!isAuthenticated" class="login-wrap">
+      <div class="login-card">
+        <h2 class="login-title">徽章攻略管理</h2>
+        <p class="login-sub">输入管理员密码以继续</p>
+        <div class="form-row">
+          <label class="form-label">管理员密码</label>
+          <input
+            type="password"
+            v-model="password"
+            class="form-input"
+            placeholder="••••••••"
+            @keyup.enter="handleLogin"
+            autocomplete="current-password"
+          />
+        </div>
+        <div v-if="loginError" class="feedback-msg error-msg">{{ loginError }}</div>
+        <button class="primary-btn full-btn" @click="handleLogin" :disabled="loginLoading">
+          {{ loginLoading ? '验证中…' : '登录' }}
+        </button>
+      </div>
+    </div>
+
+    <!-- 管理面板 -->
+    <div v-else class="admin-wrap">
+      <div class="admin-header">
+        <h1 class="admin-title">徽章攻略管理</h1>
+        <button class="logout-btn" @click="handleLogout">退出登录</button>
+      </div>
+
+      <!-- Tab 切换 -->
+      <div class="tab-bar">
+        <button
+          v-for="tab in tabs"
+          :key="tab.key"
+          class="tab-btn"
+          :class="{ active: currentTab === tab.key }"
+          @click="switchTab(tab.key)"
+        >
+          {{ tab.label }}
+          <span v-if="tab.key === 'pending' && totalPending > 0" class="tab-badge">
+            {{ totalPending }}
+          </span>
+        </button>
+      </div>
+
+      <!-- Tab 内容：待审核 -->
+      <div v-if="currentTab === 'pending'" class="tab-content">
+        <div v-if="pendingLoading" class="loading-msg">加载中…</div>
+        <div v-else-if="pendingItems.length === 0" class="empty-msg">暂无待审核攻略</div>
+        <div v-else>
+          <div class="table-wrap">
+            <table class="data-table">
+              <thead>
+                <tr>
+                  <th>ID</th>
+                  <th>角色ID</th>
+                  <th>标题</th>
+                  <th>作者</th>
+                  <th>提交时间</th>
+                  <th>操作</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr v-for="item in pendingItems" :key="item.id">
+                  <td class="td-id">#{{ item.id }}</td>
+                  <td>{{ item.char_id }}</td>
+                  <td class="td-title">{{ item.title || '（无标题）' }}</td>
+                  <td>{{ item.author_name || '—' }}</td>
+                  <td class="td-time">{{ formatTime(item.submitted_at) }}</td>
+                  <td class="td-actions">
+                    <button class="action-btn info-btn" @click="openPreview(item)">预览</button>
+                    <button class="action-btn approve-btn" @click="approveItem(item.id)">通过</button>
+                    <button class="action-btn danger-btn" @click="rejectItem(item.id)">拒绝</button>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+          <div class="pagination">
+            <button
+              class="page-btn"
+              :disabled="pendingPage <= 1"
+              @click="loadPending(pendingPage - 1)"
+            >← 上一页</button>
+            <span class="page-info">第 {{ pendingPage }} 页 / 共 {{ Math.ceil(totalPending / 20) }} 页（{{ totalPending }} 条）</span>
+            <button
+              class="page-btn"
+              :disabled="pendingPage * 20 >= totalPending"
+              @click="loadPending(pendingPage + 1)"
+            >下一页 →</button>
+          </div>
+        </div>
+      </div>
+
+      <!-- Tab 内容：已发布 -->
+      <div v-if="currentTab === 'approved'" class="tab-content">
+        <div v-if="approvedLoading" class="loading-msg">加载中…</div>
+        <div v-else-if="approvedItems.length === 0" class="empty-msg">暂无已发布攻略</div>
+        <div v-else>
+          <div class="table-wrap">
+            <table class="data-table">
+              <thead>
+                <tr>
+                  <th>ID</th>
+                  <th>角色ID</th>
+                  <th>标题</th>
+                  <th>作者</th>
+                  <th>精选</th>
+                  <th>操作</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr v-for="item in approvedItems" :key="item.id">
+                  <td class="td-id">#{{ item.id }}</td>
+                  <td>{{ item.char_id }}</td>
+                  <td class="td-title">{{ item.title || '（无标题）' }}</td>
+                  <td>{{ item.author_name || '—' }}</td>
+                  <td>
+                    <span class="featured-tag" :class="{ active: item.is_featured }">
+                      {{ item.is_featured ? '✦ 精选' : '—' }}
+                    </span>
+                  </td>
+                  <td class="td-actions">
+                    <button
+                      class="action-btn"
+                      :class="item.is_featured ? 'warn-btn' : 'approve-btn'"
+                      @click="toggleFeature(item)"
+                    >
+                      {{ item.is_featured ? '取消精选' : '设为精选' }}
+                    </button>
+                    <button
+                      class="action-btn danger-btn"
+                      @click="confirmDeleteGuide(item.id)"
+                    >删除</button>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+          <div class="pagination">
+            <button
+              class="page-btn"
+              :disabled="approvedPage <= 1"
+              @click="loadApproved(approvedPage - 1)"
+            >← 上一页</button>
+            <span class="page-info">第 {{ approvedPage }} 页 / 共 {{ Math.ceil(totalApproved / 20) }} 页（{{ totalApproved }} 条）</span>
+            <button
+              class="page-btn"
+              :disabled="approvedPage * 20 >= totalApproved"
+              @click="loadApproved(approvedPage + 1)"
+            >下一页 →</button>
+          </div>
+        </div>
+      </div>
+
+      <!-- Tab 内容：迁移静态数据 -->
+      <div v-if="currentTab === 'seed'" class="tab-content">
+        <div class="seed-warn">
+          <strong>⚠ 注意：</strong>此操作将把静态攻略文件中的所有数据批量导入数据库，
+          <strong>仅应执行一次</strong>。重复执行将产生重复数据。
+        </div>
+        <div v-if="seedDone" class="feedback-msg success-msg seed-result">
+          ✓ {{ seedResult }}
+        </div>
+        <div v-if="seedError" class="feedback-msg error-msg">{{ seedError }}</div>
+        <button
+          class="primary-btn"
+          :disabled="seedLoading || seedDone"
+          @click="handleSeed"
+        >
+          {{ seedDone ? '已完成' : seedLoading ? '迁移中…' : '开始迁移静态数据' }}
+        </button>
+      </div>
+    </div>
+
+    <!-- 预览弹窗 -->
+    <div v-if="previewItem" class="overlay" @click.self="previewItem = null">
+      <div class="preview-dialog">
+        <div class="preview-header">
+          <span>攻略预览 — 角色 {{ previewItem.char_id }}</span>
+          <button class="close-btn" @click="previewItem = null">✕</button>
+        </div>
+        <div class="preview-meta">
+          <span>标题：{{ previewItem.title || '（无标题）' }}</span>
+          <span>作者：{{ previewItem.author_name || '—' }}</span>
+        </div>
+        <HuizhangPreviewImage
+          v-if="previewItem && previewStrategy"
+          :strategy="previewStrategy"
+          :charConfig="getCharConfig(previewItem.char_id)"
+        />
+        <p v-else class="preview-error">无法解析攻略代码</p>
+      </div>
+    </div>
+
+    <!-- 确认弹窗 -->
+    <div v-if="confirmState" class="overlay" @click.self="confirmState = null">
+      <div class="confirm-dialog">
+        <p class="confirm-msg">{{ confirmState.message }}</p>
+        <div class="confirm-actions">
+          <button
+            class="primary-btn danger-primary"
+            @click="() => { confirmState.onConfirm(); confirmState = null }"
+          >确认</button>
+          <button class="cancel-btn" @click="confirmState = null">取消</button>
+        </div>
+      </div>
+    </div>
+
+    <!-- 操作反馈 Toast -->
+    <div v-if="toastMsg" class="toast" :class="toastType">{{ toastMsg }}</div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, onMounted } from 'vue'
+import { colors } from '@/styles/colors.js'
+import { getCharConfig } from '@/data/huizhang.js'
+import { decodeStrategy } from '@/utils/huizhangCode.js'
+import { useHuizhangGuides } from '@/composables/useHuizhangGuides.js'
+import HuizhangPreviewImage from '@/components/HuizhangPreviewImage.vue'
+
+const { getWorkerBase } = useHuizhangGuides()
+
+// ── 登录态 ────────────────────────────────────────────────
+const isAuthenticated = ref(false)
+const password = ref('')
+const loginError = ref('')
+const loginLoading = ref(false)
+
+function getToken() {
+  return sessionStorage.getItem('hz_admin_token') || ''
+}
+
+function isTokenValid(token) {
+  if (!token) return false
+  try {
+    const dotIdx = token.lastIndexOf('.')
+    if (dotIdx === -1) return false
+    const payloadB64 = token.slice(0, dotIdx)
+    const padded =
+      payloadB64.replace(/-/g, '+').replace(/_/g, '/') +
+      '='.repeat((4 - (payloadB64.length % 4)) % 4)
+    const { exp } = JSON.parse(atob(padded))
+    return Date.now() < exp
+  } catch {
+    return false
+  }
+}
+
+async function handleLogin() {
+  loginError.value = ''
+  if (!password.value) {
+    loginError.value = '请输入密码'
+    return
+  }
+  loginLoading.value = true
+  try {
+    const base = getWorkerBase()
+    const res = await fetch(`${base}/api/hz/admin/auth`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ password: password.value }),
+    })
+    const data = await res.json()
+    if (!res.ok) {
+      loginError.value = data.message || '登录失败'
+    } else {
+      sessionStorage.setItem('hz_admin_token', data.token)
+      isAuthenticated.value = true
+      password.value = ''
+      loadPending()
+    }
+  } catch {
+    loginError.value = '网络错误，请检查连接'
+  } finally {
+    loginLoading.value = false
+  }
+}
+
+function handleLogout() {
+  sessionStorage.removeItem('hz_admin_token')
+  isAuthenticated.value = false
+}
+
+// ── Tab 管理 ──────────────────────────────────────────────
+const tabs = [
+  { key: 'pending', label: '待审核' },
+  { key: 'approved', label: '已发布' },
+  { key: 'seed', label: '迁移静态数据' },
+]
+const currentTab = ref('pending')
+
+function switchTab(key) {
+  currentTab.value = key
+  if (key === 'pending') loadPending()
+  if (key === 'approved') loadApproved()
+}
+
+// ── 待审核 ────────────────────────────────────────────────
+const pendingItems = ref([])
+const pendingPage = ref(1)
+const totalPending = ref(0)
+const pendingLoading = ref(false)
+
+async function loadPending(page = 1) {
+  pendingLoading.value = true
+  try {
+    const base = getWorkerBase()
+    const res = await fetch(`${base}/api/hz/admin/pending?page=${page}`, {
+      headers: { Authorization: `Bearer ${getToken()}` },
+    })
+    if (res.status === 401) { handleLogout(); return }
+    const data = await res.json()
+    pendingItems.value = data.items || []
+    totalPending.value = data.total || 0
+    pendingPage.value = page
+  } catch {
+    showToast('加载失败，请刷新重试', 'error')
+  } finally {
+    pendingLoading.value = false
+  }
+}
+
+async function approveItem(id) {
+  try {
+    const base = getWorkerBase()
+    const res = await fetch(`${base}/api/hz/admin/approve/${id}`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${getToken()}` },
+    })
+    if (res.status === 401) { handleLogout(); return }
+    const data = await res.json()
+    if (res.ok) {
+      showToast('审核通过！', 'success')
+      loadPending(pendingPage.value)
+    } else {
+      showToast(data.message || '操作失败', 'error')
+    }
+  } catch {
+    showToast('网络错误', 'error')
+  }
+}
+
+async function rejectItem(id) {
+  confirmState.value = {
+    message: `确认拒绝并删除待审核攻略 #${id}？`,
+    onConfirm: async () => {
+      try {
+        const base = getWorkerBase()
+        const res = await fetch(`${base}/api/hz/admin/pending/${id}`, {
+          method: 'DELETE',
+          headers: { Authorization: `Bearer ${getToken()}` },
+        })
+        if (res.ok) {
+          showToast('已拒绝', 'success')
+          loadPending(pendingPage.value)
+        } else {
+          const data = await res.json()
+          showToast(data.message || '操作失败', 'error')
+        }
+      } catch {
+        showToast('网络错误', 'error')
+      }
+    },
+  }
+}
+
+// ── 已发布 ────────────────────────────────────────────────
+const approvedItems = ref([])
+const approvedPage = ref(1)
+const totalApproved = ref(0)
+const approvedLoading = ref(false)
+
+async function loadApproved(page = 1) {
+  approvedLoading.value = true
+  try {
+    const base = getWorkerBase()
+    const res = await fetch(`${base}/api/hz/admin/guides?page=${page}`, {
+      headers: { Authorization: `Bearer ${getToken()}` },
+    })
+    if (res.status === 401) { handleLogout(); return }
+    const data = await res.json()
+    approvedItems.value = data.items || []
+    totalApproved.value = data.total || 0
+    approvedPage.value = page
+  } catch {
+    showToast('加载失败', 'error')
+  } finally {
+    approvedLoading.value = false
+  }
+}
+
+async function toggleFeature(item) {
+  const newVal = !item.is_featured
+  try {
+    const base = getWorkerBase()
+    const res = await fetch(`${base}/api/hz/admin/guide/${item.id}/feature`, {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${getToken()}`,
+      },
+      body: JSON.stringify({ featured: newVal }),
+    })
+    if (res.ok) {
+      item.is_featured = newVal ? 1 : 0
+      showToast(newVal ? '已设为精选' : '已取消精选', 'success')
+    } else {
+      const data = await res.json()
+      showToast(data.message || '操作失败', 'error')
+    }
+  } catch {
+    showToast('网络错误', 'error')
+  }
+}
+
+function confirmDeleteGuide(id) {
+  confirmState.value = {
+    message: `确认永久删除已发布攻略 #${id}？此操作不可撤销。`,
+    onConfirm: async () => {
+      try {
+        const base = getWorkerBase()
+        const res = await fetch(`${base}/api/hz/admin/guide/${id}`, {
+          method: 'DELETE',
+          headers: { Authorization: `Bearer ${getToken()}` },
+        })
+        if (res.ok) {
+          showToast('已删除', 'success')
+          loadApproved(approvedPage.value)
+        } else {
+          const data = await res.json()
+          showToast(data.message || '操作失败', 'error')
+        }
+      } catch {
+        showToast('网络错误', 'error')
+      }
+    },
+  }
+}
+
+// ── 静态数据迁移 ──────────────────────────────────────────
+const seedLoading = ref(false)
+const seedDone = ref(false)
+const seedResult = ref('')
+const seedError = ref('')
+
+async function handleSeed() {
+  if (seedDone.value) return
+  seedLoading.value = true
+  seedError.value = ''
+
+  try {
+    // 动态导入所有静态攻略文件
+    const modules = import.meta.glob('/src/data/huizhangdata/*.js', { eager: false })
+    const entries = []
+
+    for (const [path, loader] of Object.entries(modules)) {
+      const match = path.match(/\/(\d+)\.js$/)
+      if (!match) continue // 跳过 index.js 等非角色文件
+      const charId = match[1]
+      const mod = await loader()
+      const codes = mod.default || []
+      if (codes.length > 0) entries.push({ charId, codes })
+    }
+
+    if (entries.length === 0) {
+      seedError.value = '未找到可迁移的静态数据'
+      return
+    }
+
+    const base = getWorkerBase()
+    const res = await fetch(`${base}/api/hz/admin/seed`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${getToken()}`,
+      },
+      body: JSON.stringify({ entries }),
+    })
+    const data = await res.json()
+    if (res.ok) {
+      seedDone.value = true
+      seedResult.value = data.message
+    } else {
+      seedError.value = data.message || '迁移失败'
+    }
+  } catch (e) {
+    seedError.value = '发生错误: ' + e.message
+  } finally {
+    seedLoading.value = false
+  }
+}
+
+// ── 预览弹窗 ──────────────────────────────────────────────
+const previewItem = ref(null)
+const previewStrategy = computed(() => {
+  if (!previewItem.value) return null
+  try {
+    return decodeStrategy(previewItem.value.code)
+  } catch {
+    return null
+  }
+})
+
+function openPreview(item) {
+  previewItem.value = item
+}
+
+// ── 确认弹窗 ──────────────────────────────────────────────
+const confirmState = ref(null)
+
+// ── Toast 提示 ────────────────────────────────────────────
+const toastMsg = ref('')
+const toastType = ref('success')
+let toastTimer = null
+
+function showToast(msg, type = 'success') {
+  toastMsg.value = msg
+  toastType.value = type
+  if (toastTimer) clearTimeout(toastTimer)
+  toastTimer = setTimeout(() => { toastMsg.value = '' }, 2500)
+}
+
+// ── 工具函数 ──────────────────────────────────────────────
+function formatTime(ts) {
+  if (!ts) return '—'
+  return new Date(ts).toLocaleString('zh-CN', { hour12: false })
+}
+
+// ── 初始化 ────────────────────────────────────────────────
+onMounted(() => {
+  const token = getToken()
+  if (isTokenValid(token)) {
+    isAuthenticated.value = true
+    loadPending()
+  }
+})
+</script>
+
+<style scoped>
+.page-container {
+  min-height: 100vh;
+  background: v-bind('colors.background.primary');
+  color: v-bind('colors.text.primary');
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 0.5rem;
+}
+
+/* ── 登录界面 ── */
+.login-wrap {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+  width: 100%;
+}
+
+.login-card {
+  background: v-bind('colors.background.content');
+  border: 1px solid v-bind('colors.border.primary');
+  border-radius: 14px;
+  padding: 2rem 2.4rem;
+  width: 90%;
+  max-width: 360px;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  box-shadow: 0 8px 24px v-bind('colors.shadow.primary');
+}
+
+.login-title {
+  text-align: center;
+  margin: 0;
+  font-size: 1.2rem;
+  color: v-bind('colors.text.primary');
+}
+
+.login-sub {
+  text-align: center;
+  margin: -0.5rem 0 0;
+  color: v-bind('colors.text.tertiary');
+  font-size: 0.82rem;
+}
+
+/* ── 管理面板 ── */
+.admin-wrap {
+  width: 100%;
+  max-width: 1100px;
+  padding: 1rem 0.5rem 4rem;
+}
+
+.admin-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 1rem;
+}
+
+.admin-title {
+  font-size: 1.4rem;
+  margin: 0;
+  color: v-bind('colors.text.primary');
+}
+
+.logout-btn {
+  background: none;
+  border: 1px solid v-bind('colors.border.primary');
+  border-radius: 6px;
+  color: v-bind('colors.text.secondary');
+  padding: 0.3rem 0.8rem;
+  font-size: 0.82rem;
+  cursor: pointer;
+}
+
+.logout-btn:hover {
+  border-color: v-bind('colors.brand.cancel');
+  color: v-bind('colors.brand.cancel');
+}
+
+/* ── Tab 栏 ── */
+.tab-bar {
+  display: flex;
+  gap: 6px;
+  border-bottom: 1px solid v-bind('colors.border.primary');
+  margin-bottom: 1rem;
+}
+
+.tab-btn {
+  padding: 0.5rem 1.2rem;
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  color: v-bind('colors.text.secondary');
+  cursor: pointer;
+  font-size: 0.9rem;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  transition: all 0.15s;
+  margin-bottom: -1px;
+}
+
+.tab-btn.active {
+  color: v-bind('colors.brand.primary');
+  border-bottom-color: v-bind('colors.brand.primary');
+  font-weight: bold;
+}
+
+.tab-btn:hover:not(.active) {
+  color: v-bind('colors.text.primary');
+}
+
+.tab-badge {
+  background: v-bind('colors.brand.cancel');
+  color: white;
+  border-radius: 10px;
+  font-size: 0.7rem;
+  padding: 1px 6px;
+  font-weight: bold;
+}
+
+/* ── 表格 ── */
+.table-wrap {
+  overflow-x: auto;
+  border-radius: 10px;
+  border: 1px solid v-bind('colors.border.primary');
+}
+
+.data-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.88rem;
+}
+
+.data-table th {
+  background: v-bind('colors.background.light');
+  color: v-bind('colors.text.secondary');
+  font-weight: bold;
+  padding: 0.6rem 0.8rem;
+  text-align: left;
+  border-bottom: 1px solid v-bind('colors.border.primary');
+  white-space: nowrap;
+}
+
+.data-table td {
+  padding: 0.55rem 0.8rem;
+  border-bottom: 1px solid v-bind('colors.border.secondary');
+  color: v-bind('colors.text.primary');
+  vertical-align: middle;
+}
+
+.data-table tr:last-child td {
+  border-bottom: none;
+}
+
+.data-table tr:hover td {
+  background: v-bind('colors.background.hover');
+}
+
+.td-id {
+  color: v-bind('colors.text.tertiary');
+  font-size: 0.8rem;
+  white-space: nowrap;
+}
+
+.td-title {
+  max-width: 200px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.td-time {
+  color: v-bind('colors.text.tertiary');
+  font-size: 0.8rem;
+  white-space: nowrap;
+}
+
+.td-actions {
+  display: flex;
+  gap: 5px;
+  white-space: nowrap;
+}
+
+.action-btn {
+  padding: 0.28rem 0.7rem;
+  border-radius: 5px;
+  border: 1px solid;
+  cursor: pointer;
+  font-size: 0.8rem;
+  font-weight: bold;
+  transition: all 0.15s;
+}
+
+.info-btn {
+  border-color: v-bind('colors.brand.primary');
+  color: v-bind('colors.brand.primary');
+  background: transparent;
+}
+
+.info-btn:hover {
+  background: v-bind('colors.brand.primaryBackground');
+}
+
+.approve-btn {
+  border-color: v-bind('colors.brand.confirm');
+  color: v-bind('colors.brand.confirm');
+  background: transparent;
+}
+
+.approve-btn:hover {
+  background: v-bind('colors.status.successBg');
+}
+
+.warn-btn {
+  border-color: v-bind('colors.text.highlight');
+  color: v-bind('colors.text.highlight');
+  background: transparent;
+}
+
+.warn-btn:hover {
+  opacity: 0.8;
+}
+
+.danger-btn {
+  border-color: v-bind('colors.brand.cancel');
+  color: v-bind('colors.brand.cancel');
+  background: transparent;
+}
+
+.danger-btn:hover {
+  background: v-bind('colors.status.errorBg');
+}
+
+.featured-tag {
+  font-size: 0.78rem;
+  color: v-bind('colors.text.tertiary');
+}
+
+.featured-tag.active {
+  color: v-bind('colors.text.highlight');
+  font-weight: bold;
+}
+
+/* ── 分页 ── */
+.pagination {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.page-btn {
+  padding: 0.35rem 0.9rem;
+  border-radius: 6px;
+  border: 1px solid v-bind('colors.border.primary');
+  background: v-bind('colors.background.lighter');
+  color: v-bind('colors.text.secondary');
+  cursor: pointer;
+  font-size: 0.85rem;
+}
+
+.page-btn:hover:not(:disabled) {
+  border-color: v-bind('colors.brand.primary');
+  color: v-bind('colors.brand.primary');
+}
+
+.page-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.page-info {
+  color: v-bind('colors.text.tertiary');
+  font-size: 0.82rem;
+}
+
+/* ── 迁移数据 ── */
+.seed-warn {
+  background: v-bind('colors.status.errorBg');
+  border: 1px solid v-bind('colors.brand.cancel');
+  border-radius: 8px;
+  padding: 0.8rem 1rem;
+  color: v-bind('colors.status.error');
+  font-size: 0.88rem;
+  line-height: 1.6;
+  margin-bottom: 1rem;
+}
+
+.seed-result {
+  margin-bottom: 1rem;
+}
+
+/* ── 通用组件 ── */
+.form-row {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.form-label {
+  font-weight: bold;
+  font-size: 0.85rem;
+  color: v-bind('colors.text.secondary');
+}
+
+.form-input {
+  padding: 10px 12px;
+  border-radius: 8px;
+  border: 1px solid v-bind('colors.input.border');
+  background: v-bind('colors.input.background');
+  color: v-bind('colors.input.text');
+  font-size: 0.95rem;
+}
+
+.form-input:focus {
+  outline: none;
+  border-color: v-bind('colors.brand.primary');
+}
+
+.full-btn {
+  width: 100%;
+}
+
+.primary-btn {
+  padding: 0.6rem 1.4rem;
+  border-radius: 8px;
+  border: none;
+  background: v-bind('colors.brand.primary');
+  color: v-bind('colors.text.black');
+  font-weight: bold;
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.primary-btn:hover:not(:disabled) {
+  background: v-bind('colors.brand.hover');
+}
+
+.primary-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.danger-primary {
+  background: v-bind('colors.brand.cancel');
+  color: #fff;
+}
+
+.danger-primary:hover:not(:disabled) {
+  background: v-bind('colors.brand.cancelHover');
+}
+
+.cancel-btn {
+  padding: 0.6rem 1.4rem;
+  border-radius: 8px;
+  border: 1px solid v-bind('colors.border.primary');
+  background: v-bind('colors.background.lighter');
+  color: v-bind('colors.text.secondary');
+  font-size: 0.9rem;
+  cursor: pointer;
+}
+
+.cancel-btn:hover {
+  border-color: v-bind('colors.brand.primary');
+  color: v-bind('colors.brand.primary');
+}
+
+.feedback-msg {
+  font-size: 0.85rem;
+  padding: 8px 12px;
+  border-radius: 6px;
+}
+
+.error-msg {
+  background: v-bind('colors.status.errorBg');
+  color: v-bind('colors.status.error');
+}
+
+.success-msg {
+  background: v-bind('colors.status.successBg');
+  color: v-bind('colors.status.success');
+}
+
+.loading-msg,
+.empty-msg {
+  text-align: center;
+  color: v-bind('colors.text.tertiary');
+  padding: 2rem 0;
+  font-size: 0.9rem;
+}
+
+.tab-content {
+  margin-top: 0.5rem;
+}
+
+/* ── 预览弹窗 ── */
+.overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background-color: v-bind('colors.background.overlay');
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+}
+
+.preview-dialog {
+  background: v-bind('colors.background.content');
+  border: 1px solid v-bind('colors.border.primary');
+  border-radius: 14px;
+  padding: 1.2rem;
+  width: 90%;
+  max-width: 560px;
+  max-height: 85vh;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+}
+
+.preview-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-weight: bold;
+  color: v-bind('colors.text.primary');
+}
+
+.preview-meta {
+  display: flex;
+  gap: 1rem;
+  font-size: 0.82rem;
+  color: v-bind('colors.text.tertiary');
+}
+
+.preview-error {
+  text-align: center;
+  color: v-bind('colors.status.error');
+  font-size: 0.88rem;
+}
+
+.close-btn {
+  background: none;
+  border: none;
+  color: v-bind('colors.text.tertiary');
+  cursor: pointer;
+  font-size: 1rem;
+  padding: 2px 6px;
+}
+
+.close-btn:hover {
+  color: v-bind('colors.brand.cancel');
+}
+
+/* ── 确认弹窗 ── */
+.confirm-dialog {
+  background: v-bind('colors.background.content');
+  border: 1px solid v-bind('colors.border.primary');
+  border-radius: 12px;
+  padding: 1.5rem 2rem;
+  width: 90%;
+  max-width: 360px;
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+  box-shadow: 0 8px 24px v-bind('colors.shadow.primary');
+}
+
+.confirm-msg {
+  text-align: center;
+  color: v-bind('colors.text.primary');
+  font-size: 0.95rem;
+  margin: 0;
+  line-height: 1.5;
+}
+
+.confirm-actions {
+  display: flex;
+  gap: 10px;
+  justify-content: center;
+}
+
+/* ── Toast ── */
+.toast {
+  position: fixed;
+  bottom: 2rem;
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 0.6rem 1.4rem;
+  border-radius: 8px;
+  font-size: 0.9rem;
+  font-weight: bold;
+  z-index: 2000;
+  box-shadow: 0 4px 12px v-bind('colors.shadow.primary');
+  animation: fadeIn 0.2s ease;
+}
+
+.toast.success {
+  background: v-bind('colors.status.success');
+  color: #fff;
+}
+
+.toast.error {
+  background: v-bind('colors.status.error');
+  color: #fff;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; transform: translateX(-50%) translateY(10px); }
+  to { opacity: 1; transform: translateX(-50%) translateY(0); }
+}
+
+@media (max-width: 600px) {
+  .td-actions {
+    flex-direction: column;
+    gap: 3px;
+  }
+
+  .td-title {
+    max-width: 120px;
+  }
+}
+</style>

--- a/src/views/HuizhangCharPage.vue
+++ b/src/views/HuizhangCharPage.vue
@@ -69,41 +69,30 @@ import { getCharConfig } from '@/data/huizhang.js'
 import { decodeStrategy } from '@/utils/huizhangCode.js'
 import { colors } from '@/styles/colors.js'
 import HuizhangPreviewImage from '@/components/HuizhangPreviewImage.vue'
+import { useHuizhangGuides } from '@/composables/useHuizhangGuides.js'
 
 const route = useRoute()
 const router = useRouter()
 const charId = computed(() => route.params.charId)
 
-const strategies = ref([]) // [{ code: string, data: Object }]
-const loading = ref(true)
 const showImportInput = ref(false)
 const importCodeInput = ref('')
 const importCodeError = ref('')
 
-const strategyModules = import.meta.glob('/src/data/huizhangdata/*.js', { eager: false })
+const { init, getGuidesForChar, loading } = useHuizhangGuides()
 
 const card = computed(() => allCards.find((c) => c.id === charId.value) || null)
 const charConfig = computed(() => getCharConfig(charId.value))
 
+// 从 D1 加载的攻略列表，格式与原来保持兼容
+const strategies = computed(() =>
+  getGuidesForChar(charId.value)
+    .filter((g) => g.data !== null)
+    .map((g) => ({ code: g.code, data: g.data })),
+)
+
 onMounted(async () => {
-  const path = `/src/data/huizhangdata/${charId.value}.js`
-  const loader = strategyModules[path]
-  if (loader) {
-    try {
-      const mod = await loader()
-      const codes = mod.default || []
-      strategies.value = codes.map((code) => {
-        try {
-          return { code, data: decodeStrategy(code) }
-        } catch {
-          return null
-        }
-      }).filter(Boolean)
-    } catch {
-      strategies.value = []
-    }
-  }
-  loading.value = false
+  await init()
 })
 
 const createNew = () => {

--- a/src/views/HuizhangHome.vue
+++ b/src/views/HuizhangHome.vue
@@ -124,15 +124,14 @@ import { ref, computed, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { allCards } from '@/data/cards.js'
 import { getCharConfig, HUIZHANG_SHAPES, HUIZHANG_TYPES } from '@/data/huizhang.js'
-import { decodeStrategy } from '@/utils/huizhangCode.js'
 import { colors } from '@/styles/colors.js'
-import { FEATURED_STRATEGIES } from '@/data/huizhangdata/index.js'
 import CharacterSelector from '@/components/CharacterSelector.vue'
+import { useHuizhangGuides } from '@/composables/useHuizhangGuides.js'
 
 const router = useRouter()
 const selectedCharId = ref('')
 
-const strategyModules = import.meta.glob('/src/data/huizhangdata/*.js', { eager: false })
+const { init, getFeaturedGuides } = useHuizhangGuides()
 
 const baseCharacterList = computed(() => allCards.filter((c) => c.id.match(/^\d+$/)))
 
@@ -169,25 +168,20 @@ const cardMap = computed(() => {
   return m
 })
 
-// 精选攻略数据
-const featuredItems = ref([])
+// 精选攻略数据（从 D1 实时加载，缓存4小时）
+const featuredItems = computed(() =>
+  getFeaturedGuides()
+    .filter((g) => g.data !== null)
+    .map((g) => ({
+      charId: g.charId,
+      strategy: g.data,
+      card: cardMap.value.get(g.charId),
+      charConfig: getCharConfig(g.charId),
+    })),
+)
 
 onMounted(async () => {
-  const loaded = []
-  for (const { charId, index } of FEATURED_STRATEGIES) {
-    const path = `/src/data/huizhangdata/${charId}.js`
-    const loader = strategyModules[path]
-    if (!loader) continue
-    try {
-      const mod = await loader()
-      const codes = mod.default || []
-      const code = codes[index]
-      if (!code) continue
-      const strategy = decodeStrategy(code)
-      loaded.push({ charId, strategy, card: cardMap.value.get(charId), charConfig: getCharConfig(charId) })
-    } catch { /* 跳过 */ }
-  }
-  featuredItems.value = loaded
+  await init()
 })
 
 const goToChar = (charId) => router.push(`/huizhang/char/${charId}`)

--- a/src/views/HuizhangPage.vue
+++ b/src/views/HuizhangPage.vue
@@ -72,17 +72,12 @@
         <div class="control-group"></div>
 
         <div class="action-buttons">
-          <button @click="exportData" class="export-btn">
-            {{ showCopied ? '✓ 已复制！' : '导出代码' }}
+          <button @click="openSubmitDialog" class="export-btn" :disabled="isCustomChar">
+            投稿攻略
           </button>
           <button @click="generateImage" class="generate-btn">导出攻略图</button>
         </div>
-        <!-- 代码文本框（剪贴板不可用时显示） -->
-        <div v-if="exportCodeText" class="code-export-area">
-          <label class="code-export-label">攻略代码</label>
-          <textarea class="code-export-textarea" :value="exportCodeText" readonly rows="3"
-            @click="$event.target.select()"></textarea>
-        </div>
+        <p v-if="isCustomChar" class="custom-char-hint">自定义角色暂不支持投稿</p>
       </div>
 
       <div class="preview-wrapper" ref="previewWrapper">
@@ -204,6 +199,47 @@
     <button @click="closeAgreementPopUp" class="action-button">我已阅读并同意</button>
   </PopUp>
 
+  <!-- 投稿攻略弹窗 -->
+  <div v-if="showSubmitDialog" class="overlay" @click.self="showSubmitDialog = false">
+    <div class="submit-confirm-form" @click.stop>
+      <h3 class="submit-title">投稿攻略</h3>
+      <p class="submit-sub">投稿后需要管理员审核，审核通过后将显示在攻略列表中。</p>
+
+      <div class="submit-info-row">
+        <span class="submit-info-label">角色</span>
+        <span class="submit-info-value">{{ selectedCardInfo.name }}</span>
+      </div>
+      <div v-if="customTitle" class="submit-info-row">
+        <span class="submit-info-label">攻略名称</span>
+        <span class="submit-info-value">{{ customTitle }}</span>
+      </div>
+      <div v-if="authorName" class="submit-info-row">
+        <span class="submit-info-label">署名</span>
+        <span class="submit-info-value">{{ authorName }}</span>
+      </div>
+
+      <div class="form-row">
+        <label>激活码 <span class="required">*</span></label>
+        <input v-model="submitLicenseKey" class="input-select" placeholder="与抽卡记录功能的相同" autocomplete="off" />
+        <span class="submit-sub">若没有激活码，请小程序搜索织夜工具箱并联系客服</span>
+        <label class="checkbox-row">
+          <input type="checkbox" v-model="saveKey" />
+          <span>保存激活码到本地（下次自动填充）</span>
+        </label>
+      </div>
+
+      <div v-if="submitError" class="feedback-msg error-msg">{{ submitError }}</div>
+      <div v-if="submitSuccess" class="feedback-msg success-msg">{{ submitSuccess }}</div>
+
+      <div class="form-actions">
+        <button class="action-button" :disabled="submitLoading" @click="handleSubmit">
+          {{ submitLoading ? '提交中…' : '提交审核' }}
+        </button>
+        <button class="action-button cancel" @click="showSubmitDialog = false">取消</button>
+      </div>
+    </div>
+  </div>
+
   <!-- 自定义角色弹窗 -->
   <div v-if="showCustomCharForm" class="overlay" @click="showCustomCharForm = false">
     <div class="custom-character-form" @click.stop>
@@ -267,6 +303,7 @@
 <script setup>
 import { ref, computed, watch, onMounted, onUnmounted, nextTick } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
+import { useHuizhangGuides } from '@/composables/useHuizhangGuides.js'
 import { allCards } from '@/data/cards.js'
 import { colors } from '@/styles/colors.js'
 import {
@@ -296,12 +333,19 @@ const previewScale = ref(1)
 const isSelectionMode = ref(true)
 const showAgreementPopUp = ref(false)
 
-// 导出代码相关
-const showCopied = ref(false)
-const exportCodeText = ref('')
+// 投稿攻略相关
+const showSubmitDialog = ref(false)
+const submitLicenseKey = ref('')
+const saveKey = ref(true)
+const submitLoading = ref(false)
+const submitError = ref('')
+const submitSuccess = ref('')
+
+const isCustomChar = computed(() => selectedCharId.value?.startsWith('custom_temp_'))
 
 const route = useRoute()
 const router = useRouter()
+const { getWorkerBase } = useHuizhangGuides()
 
 // 自定义角色相关
 const tempCustomChar = ref(null)
@@ -603,29 +647,82 @@ const getStarImage = (level, starIndex) => {
   return `/images/huizhang/icon_star_${typeIndex}.webp`
 }
 
-// 导出为短代码
-const exportData = async () => {
-  const data = {
-    charId: selectedCharId.value,
-    stars: recommendedStars.value,
-    customTitle: customTitle.value,
-    recText: recommendText.value,
-    authorName: authorName.value,
-    slots: currentSlots.value,
+// 打开投稿确认框
+const openSubmitDialog = () => {
+  const saved = localStorage.getItem('hz_license_key')
+  if (saved) {
+    submitLicenseKey.value = saved
+    saveKey.value = true
   }
-  if (tempCustomChar.value && selectedCharId.value === tempCustomChar.value.id) {
-    data.customChar = tempCustomChar.value
+  submitError.value = ''
+  submitSuccess.value = ''
+  showSubmitDialog.value = true
+}
+
+// 提交攻略
+const handleSubmit = async () => {
+  submitError.value = ''
+  submitSuccess.value = ''
+
+  if (!submitLicenseKey.value.trim()) {
+    submitError.value = '请输入激活码'
+    return
   }
-  const code = encodeStrategy(data)
-  exportCodeText.value = code
+
+  if (saveKey.value) {
+    localStorage.setItem('hz_license_key', submitLicenseKey.value.trim())
+  }
+
+  let code
   try {
-    await navigator.clipboard.writeText(code)
-    showCopied.value = true
-    setTimeout(() => {
-      showCopied.value = false
-    }, 2500)
+    code = encodeStrategy({
+      charId: selectedCharId.value,
+      stars: recommendedStars.value,
+      customTitle: customTitle.value,
+      recText: recommendText.value,
+      authorName: authorName.value,
+      slots: currentSlots.value,
+    })
   } catch {
-    // 剪贴板不可用时仍显示代码文本框让用户手动复制
+    submitError.value = '攻略编码失败，请检查配置后重试'
+    return
+  }
+
+  submitLoading.value = true
+  try {
+    const base = getWorkerBase()
+    const res = await fetch(`${base}/api/hz/submit`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-License-Key': submitLicenseKey.value.trim(),
+      },
+      body: JSON.stringify({
+        charId: selectedCharId.value,
+        code,
+        title: customTitle.value.trim(),
+        authorName: authorName.value.trim(),
+      }),
+    })
+    const resData = await res.json()
+    if (!res.ok) {
+      if (res.status === 429 && resData.timeLeft) {
+        const secs = Math.ceil(resData.timeLeft / 1000)
+        submitError.value = `提交过于频繁，请 ${secs} 秒后再试`
+      } else {
+        submitError.value = resData.message || '提交失败，请稍后重试'
+      }
+    } else {
+      submitSuccess.value = resData.message || '提交成功！攻略将在审核通过后显示。'
+      setTimeout(() => {
+        showSubmitDialog.value = false
+        submitSuccess.value = ''
+      }, 2000)
+    }
+  } catch {
+    submitError.value = '网络错误，请检查网络连接后重试'
+  } finally {
+    submitLoading.value = false
   }
 }
 
@@ -1045,6 +1142,18 @@ textarea {
   cursor: pointer;
 }
 
+.export-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.custom-char-hint {
+  font-size: 0.8rem;
+  color: v-bind('colors.text.tertiary');
+  margin: -4px 0 0;
+  text-align: center;
+}
+
 .action-buttons {
   display: flex;
   gap: 10px;
@@ -1076,29 +1185,96 @@ textarea {
   color: v-bind('colors.brand.primary');
 }
 
-.code-export-area {
-  margin-top: 0.6rem;
+/* 投稿弹窗 */
+.submit-confirm-form {
+  background-color: v-bind('colors.background.content');
+  padding: 1.4rem 1.6rem;
+  border-radius: 14px;
+  box-shadow: 0 8px 24px v-bind('colors.shadow.primary');
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 0.9rem;
+  width: 90%;
+  max-width: 420px;
+  border: 1px solid v-bind('colors.border.primary');
+  max-height: 90vh;
+  overflow-y: auto;
 }
 
-.code-export-label {
+.submit-title {
+  text-align: center;
+  margin: 0;
+  color: v-bind('colors.text.primary');
+  font-size: 1.1rem;
+}
+
+.submit-sub {
+  text-align: center;
+  margin: -0.4rem 0 0;
+  color: v-bind('colors.text.tertiary');
+  font-size: 0.8rem;
+  line-height: 1.4;
+}
+
+.submit-info-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.9rem;
+  padding: 4px 0;
+  border-bottom: 1px solid v-bind('colors.border.secondary');
+}
+
+.submit-info-label {
+  color: v-bind('colors.text.secondary');
+  font-weight: bold;
+  min-width: 5em;
+  flex-shrink: 0;
+}
+
+.submit-info-value {
+  color: v-bind('colors.text.primary');
+}
+
+.required {
+  color: v-bind('colors.brand.cancel');
+}
+
+.input-with-eye {
+  display: flex;
+  gap: 6px;
+}
+
+.checkbox-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
   font-size: 0.82rem;
   color: v-bind('colors.text.secondary');
+  cursor: pointer;
+  font-weight: normal;
 }
 
-.code-export-textarea {
-  width: 100%;
-  background: v-bind('colors.background.light');
-  border: 1px solid v-bind('colors.border.primary');
+.checkbox-row input[type='checkbox'] {
+  accent-color: v-bind('colors.brand.primary');
+  cursor: pointer;
+}
+
+.feedback-msg {
+  font-size: 0.85rem;
+  padding: 8px 12px;
   border-radius: 6px;
-  color: v-bind('colors.text.primary');
-  font-size: 0.75rem;
-  padding: 0.5rem;
-  resize: vertical;
-  box-sizing: border-box;
-  font-family: monospace;
+  text-align: center;
+}
+
+.error-msg {
+  background: v-bind('colors.status.errorBg');
+  color: v-bind('colors.status.error');
+}
+
+.success-msg {
+  background: v-bind('colors.status.successBg');
+  color: v-bind('colors.status.success');
 }
 
 /* --- 预览区 --- */

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -20,3 +20,9 @@ class_name = "TaskRunner" # 调用DO数据库的函数
 [[migrations]]
 tag = "v1"
 new_sqlite_classes = ["TaskRunner"]
+
+# 徽章攻略 D1 数据库
+[[d1_databases]]
+binding = "HZ_DB"
+database_name = "gacha-party-hz"
+database_id = "44011edb-72e6-4b5d-914d-29293f3bf018"


### PR DESCRIPTION
### ✨ 本次 PR 解决了什么问题？

徽章攻略页面的攻略数据原先全部硬编码在本地静态 JS 文件中，无法动态更新，也没有任何投稿渠道。本次 PR 将数据层迁移至 Cloudflare D1，并实现了完整的玩家投稿 + 管理员审核工作流，同时引入了前端智能缓存策略以尽量减少数据库请求次数。

---

### 💡 解决方案

#### 基础设施

* 新增 `hz_schema.sql`，定义三张 D1 表：`hz_guides`（已审核发布的攻略）、`hz_pending`（待审核投稿）、`hz_guide_meta`（版本号，用于增量更新判断）。
* 修改 `wrangler.toml`，绑定 D1 数据库 `gacha-party-hz`（`HZ_DB`）。

#### Worker API（`_worker.js`）

新增 Hono 子路由 `/api/hz/*`，共七个端点，最大化复用 D1 batch API 以减少网络往返：

| 端点 | 说明 |
|---|---|
| `GET /api/hz/version` | 轻量版本检查（1次 D1 读） |
| `GET /api/hz/guides` | 全量拉取（1次 D1 batch） |
| `POST /api/hz/submit` | 玩家投稿：复用 Ed25519 激活码校验，3 分钟/userId 限速（1读+1写） |
| `POST /api/hz/admin/auth` | 密码登录（SHA-256 哈希）+ HMAC-SHA256 JWT，KV 记录失败次数，5 次错误后封禁 IP 60 分钟 |
| `GET /admin/pending` | 待审核列表（分页，batch COUNT+SELECT） |
| `POST /admin/approve/:id` | 审核通过：1次 batch 完成「读 pending → 写 guides → 删 pending → 更新版本号」4 条语句 |
| `DELETE /admin/pending/:id` \| `DELETE /admin/guide/:id` \| `PATCH /admin/guide/:id/feature` | 拒绝/删除/切换精选，各1次 batch |
| `POST /admin/seed` | 一次性静态数据迁移，分批插入（99条/批） |

管理员密码、HMAC 密钥、哈希盐均通过 Cloudflare 环境变量注入，不出现在源码中，开源安全可行。

#### 前端数据层（`src/composables/useHuizhangGuides.js`）

* 模块级单例，多组件共享同一数据源，避免重复请求。
* 4 小时 localStorage 缓存：4 小时内直接读缓存（0 次 D1 请求）；超时后先轻量拉取 version，版本相同则仅更新时间戳（1 次请求），版本不同才全量刷新（2 次请求）。
* `_initPromise` 防止同一页面内并发调用产生重复请求。

#### 页面改造

* 修改 `src/views/HuizhangCharPage.vue`：移除 `import.meta.glob` 静态加载，改用 `useHuizhangGuides` composable；删除投稿入口（已移至编辑器）。
* 修改 `src/views/HuizhangHome.vue`：精选攻略从 `FEATURED_STRATEGIES` 静态导入改为 `getFeaturedGuides()` 动态获取。
* 修改 `src/views/HuizhangPage.vue`（编辑器）：将「导出代码」按钮替换为「投稿攻略」，点击后弹出确认框，自动读取编辑器内已填写的角色、攻略名称、署名，仅需输入激活码即可投稿；激活码可保存到 localStorage 自动填充。

#### 新增组件与页面

* 新增 `src/components/HuizhangSubmitModal.vue`：独立投稿弹窗（保留供未来复用）。
* 新增 `src/views/HuizhangAdmin.vue`：管理员面板，含三个标签页（待审核 / 已发布 / 迁移静态数据），内联确认对话框，Toast 通知，全主题适配。
* 修改 `src/main.js`：新增 `/huizhang/admin` 路由。

---

### 🧪 测试方法

* 本地使用 `npm run dev`（Vite，5173 端口）+ `npm run worker`（Wrangler，8787 端口）联调。
* 使用 MCP 工具在 Cloudflare D1 控制台创建数据库并执行 `hz_schema.sql` 建表。
* 验证 `GET /api/hz/guides` 返回正确 JSON 结构，前端首次加载写入 localStorage 缓存。
* 验证 4 小时缓存逻辑：手动将 `hz_guide_last_check` 置 0，确认触发 version 检查。
* 在编辑器页面点击「投稿攻略」，测试激活码自动填充、3 分钟限速报错（含剩余秒数）、成功提示后自动关闭弹窗。
* 访问 `/huizhang/admin`，测试错误密码 5 次后 IP 封禁，正确登录后执行审核通过/拒绝/精选切换/删除全流程。
* 执行「迁移静态数据」，确认原有静态攻略导入 D1 后在列表页正常显示。
* 确认自定义角色时「投稿攻略」按钮置灰不可点击，并显示提示文字。

---

### ✅ 检查清单

* [x] 我的代码遵循了项目的代码风格指南。
* [x] 我已对我的代码进行了充分测试。
* [x] 我已确认我的修改不会引入新的 Bug。
* [x] 提交信息符合 Conventional Commits 规范。

> ⚠️ **部署前置条件**：需在 Cloudflare Dashboard 的 Worker 环境变量中配置 `ADMIN_SALT`、`ADMIN_PASSWORD_HASH`、`ADMIN_SECRET` 三个变量，详见 `hz_schema.sql` 注释。